### PR TITLE
DNSSL options are concatenated if specified with trailing . 

### DIFF
--- a/send.c
+++ b/send.c
@@ -391,7 +391,7 @@ send_ra(struct Interface *iface, struct in6_addr *dest)
 
 				if (label[0] == '.')
 					label++;
-				else {
+				if (label[0] == '\0')
 					buff_dest = len;
 					send_ra_inc_len(&len, 1);
 					buff[buff_dest] = 0;


### PR DESCRIPTION
Refer to: http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=634485
