### PR TITLE
fix builds on newer Linux arches

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -151,6 +151,7 @@ AC_CHECK_HEADERS( \
 	net/if_types.h \
 	sys/param.h \
 	sys/sockio.h \
+	sys/sysctl.h \
 	sys/time.h \
 	time.h \
 )

--- a/includes.h
+++ b/includes.h
@@ -72,7 +72,9 @@
 
 #include <arpa/inet.h>
 
-#include <sys/sysctl.h>
+#ifdef HAVE_SYS_SYSCTL_H
+# include <sys/sysctl.h>
+#endif
 
 #include <net/if.h>
 

--- a/radvd.c
+++ b/radvd.c
@@ -761,7 +761,9 @@ check_conffile_perm(const char *username, const char *conf_file)
 int
 check_ip6_forwarding(void)
 {
+#ifdef HAVE_SYS_SYSCTL_H
 	int forw_sysctl[] = { SYSCTL_IP6_FORWARDING };
+#endif
 	int value;
 	size_t size = sizeof(value);
 	FILE *fp = NULL;
@@ -777,18 +779,22 @@ check_ip6_forwarding(void)
 		}
 		fclose(fp);
 	}
-	else
+	else {
 		flog(LOG_DEBUG, "Correct IPv6 forwarding procfs entry not found, "
 	                       "perhaps the procfs is disabled, "
 	                        "or the kernel interface has changed?");
+		value = -1;
+	}
 #endif /* __linux__ */
 
+#ifdef HAVE_SYS_SYSCTL_H
 	if (!fp && sysctl(forw_sysctl, sizeof(forw_sysctl)/sizeof(forw_sysctl[0]),
 	    &value, &size, NULL, 0) < 0) {
 		flog(LOG_DEBUG, "Correct IPv6 forwarding sysctl branch not found, "
 			"perhaps the kernel interface has changed?");
 		return(0);	/* this is of advisory value only */
 	}
+#endif
 
 	if (value != 1 && !warned) {
 		warned = 1;


### PR DESCRIPTION
Newer Linux ports are dropping sysctl support.  If you try to even
include the header, you'll get build failures:
/usr/include/bits/sysctl.h:19:3: error: #error "sysctl system call is unsupported"

Check for the header before we try to use it.

Signed-off-by: Mike Frysinger vapier@gentoo.org
