### PR TITLE
better check for sysctl() availability

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -160,7 +160,6 @@ AC_CHECK_HEADERS( \
 	net/if_types.h \
 	sys/param.h \
 	sys/sockio.h \
-	sys/sysctl.h \
 	sys/time.h \
 	time.h \
 )
@@ -183,6 +182,7 @@ AC_MSG_RESULT(no))
 dnl Checks for library functions.
 AC_CHECK_FUNCS(getopt_long)
 AC_CHECK_FUNCS(ppoll)
+AC_CHECK_FUNCS(sysctl)
 
 CONDITIONAL_SOURCES="device-${arch}.${OBJEXT} ${CONDITIONAL_SOURCES}"
 if test x${arch} = xlinux ; then

--- a/device-linux.c
+++ b/device-linux.c
@@ -183,7 +183,7 @@ int check_ip6_forwarding(void)
 		value = -1;
 	}
 
-#ifdef HAVE_SYS_SYSCTL_H
+#ifdef HAVE_SYSCTL
 	int forw_sysctl[] = { SYSCTL_IP6_FORWARDING };
 	size_t size = sizeof(value);
 	if (!fp && sysctl(forw_sysctl, sizeof(forw_sysctl) / sizeof(forw_sysctl[0]), &value, &size, NULL, 0) < 0) {


### PR DESCRIPTION
As it was mentioned before some Linux ports are dropping sysctl support.
But the problem happens if libc in use still installs "sys/sysctl.h" header
even if kernel doesn't support sysctl.

This is exactly the case with uClibc and probably other implementations of libc.
But if we check for existing "sysctl" symbol in libc we're golden at least in
compile-time because libc provides some stub at least.

Signed-off-by: Alexey Brodkin abrodkin@synopsys.com
