### PR TITLE
fixed: better check for sysctl() availability - builds on platforms with...

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -160,7 +160,6 @@ AC_CHECK_HEADERS( \
 	net/if_types.h \
 	sys/param.h \
 	sys/sockio.h \
-	sys/sysctl.h \
 	sys/time.h \
 	time.h \
 )
@@ -183,6 +182,7 @@ AC_MSG_RESULT(no))
 dnl Checks for library functions.
 AC_CHECK_FUNCS(getopt_long)
 AC_CHECK_FUNCS(ppoll)
+AC_CHECK_FUNCS(sysctl)
 
 CONDITIONAL_SOURCES="device-${arch}.${OBJEXT} ${CONDITIONAL_SOURCES}"
 if test x${arch} = xlinux ; then

--- a/device-linux.c
+++ b/device-linux.c
@@ -183,7 +183,7 @@ int check_ip6_forwarding(void)
 		value = -1;
 	}
 
-#ifdef HAVE_SYS_SYSCTL_H
+#ifdef HAVE_SYSCTL
 	int forw_sysctl[] = { SYSCTL_IP6_FORWARDING };
 	size_t size = sizeof(value);
 	if (!fp && sysctl(forw_sysctl, sizeof(forw_sysctl) / sizeof(forw_sysctl[0]), &value, &size, NULL, 0) < 0) {

--- a/includes.h
+++ b/includes.h
@@ -72,7 +72,7 @@
 
 #include <arpa/inet.h>
 
-#ifdef HAVE_SYS_SYSCTL_H
+#ifdef HAVE_SYSCTL
 #include <sys/sysctl.h>
 #endif
 


### PR DESCRIPTION
... sysctl

This commit fixes an build issue on machines which actually still have sysctl.
As of now this is x86{_64} with glibc for example.

As it was mentioned before some Linux ports are dropping sysctl support.
This is intentional move and in future versions of Linux kernel this system
call will eventually go away. As a good alternative one may and should use
procfs (/proc/sys).

Currently we chech if corresponding header "sys/sysctl.h" exists.
But the problem happens if libc in use still installs "sys/sysctl.h" header
while provides no implementation for it.

This is exactly the case with uClibc and probably other implementations of libc.
But if we check for existing "sysctl" symbol in libc we're golden at least in
compile-time because libc provides some stub at least.

Signed-off-by: Alexey Brodkin abrodkin@synopsys.com
