### PR TITLE
By default, Make PIO lifetimes depend on the Router Lifetime

### DIFF
--- a/defaults.h
+++ b/defaults.h
@@ -55,9 +55,10 @@
 
 /* Each prefix has an associated: */
 
-#define DFLT_AdvValidLifetime 86400 /* seconds */
+#define DFLT_AdvPreferredLifetime 1800 /* seconds */
+#define DFLT_PreferredLifetimeMult 48
+#define DFLT_AdvValidLifetime (DFLT_AdvPreferredLifetime * DFLT_PreferredLifetimeMult) /* seconds */
 #define DFLT_AdvOnLinkFlag 1
-#define DFLT_AdvPreferredLifetime 14400 /* seconds */
 #define DFLT_AdvAutonomousFlag 1
 #define DFLT_DeprecatePrefixFlag 0
 #define DFLT_DecrementLifetimesFlag 0
@@ -134,7 +135,6 @@
 #define MAX_PrefixLen 128
 
 /* SLAAC (RFC4862) Constants and Derived Values */
-#define MIN_AdvValidLifetime 7200 /* 2 hours in secs */
 
 /*
  * Mobile IPv6 extensions, off by default

--- a/radvd.conf.5.man
+++ b/radvd.conf.5.man
@@ -13,7 +13,7 @@
 .\"
 .\"
 .\"
-.TH RADVD.CONF 5 "4 Jan 2011" "radvd @VERSION@" ""
+.TH RADVD.CONF 5 "16 March 2020" "radvd @VERSION@" ""
 .SH NAME
 radvd.conf \- configuration file of the router advertisement daemon
 .B radvd
@@ -433,13 +433,14 @@ determination.  The symbolic value
 represents infinity (i.e. a value of all one bits (0xffffffff)).
 The valid lifetime is also used by RFC 4862.
 
-Note that clients will ignore AdvValidLifetime of an existing prefix
+Note that legacy clients will ignore AdvValidLifetime of an existing prefix
 if the lifetime is below two hours, as required in RFC 4862 Section 5.5.3
 point e).
 
 Note: RFC4861's suggested default value is significantly longer: 30 days.
+Please see IETF I-D draft-gont-6man-slaac-renum.
 
-Default: 86400 seconds (1 day)
+Default: 48 * AdvDefaultLifetime seconds (typically 1 day)
 
 .TP
 .BR "AdvPreferredLifetime " seconds "" | infinity
@@ -453,8 +454,9 @@ represents infinity (i.e. a value of all one bits (0xffffffff)).
 See RFC 4862.
 
 Note: RFC4861's suggested default value is significantly longer: 7 days.
+Please see IETF I-D draft-gont-6man-slaac-renum.
 
-Default: 14400 seconds (4 hours)
+Default: AdvDefaultLifetime seconds (typically 30 minutes)
 
 .TP
 .BR DeprecatePrefix " " on | off

--- a/radvd.h
+++ b/radvd.h
@@ -300,6 +300,7 @@ struct Interface *find_iface_by_index(struct Interface *iface, int index);
 struct Interface *find_iface_by_name(struct Interface *iface, const char *name);
 struct Interface *find_iface_by_time(struct Interface *iface_list);
 void dnssl_init_defaults(struct AdvDNSSL *, struct Interface *);
+void update_config_dependent_defaults(struct Interface *);
 void for_each_iface(struct Interface *ifaces, void (*foo)(struct Interface *iface, void *), void *data);
 void free_ifaces(struct Interface *ifaces);
 void iface_init_defaults(struct Interface *);

--- a/send.c
+++ b/send.c
@@ -227,12 +227,7 @@ static void add_ra_option_prefix(struct safe_buffer *sb, struct AdvPrefix const 
 	pinfo.nd_opt_pi_flags_reserved |= (prefix->AdvRouterAddr) ? ND_OPT_PI_FLAG_RADDR : 0;
 
 	if (cease_adv && prefix->DeprecatePrefixFlag) {
-		/* RFC4862, 5.5.3, step e) */
-		if (prefix->curr_validlft < MIN_AdvValidLifetime) {
-			pinfo.nd_opt_pi_valid_time = htonl(prefix->curr_validlft);
-		} else {
-			pinfo.nd_opt_pi_valid_time = htonl(MIN_AdvValidLifetime);
-		}
+		pinfo.nd_opt_pi_valid_time = 0;
 		pinfo.nd_opt_pi_preferred_time = 0;
 	} else {
 		pinfo.nd_opt_pi_valid_time = htonl(prefix->curr_validlft);


### PR DESCRIPTION
radvd already deviates from RFC4861 when it comes to prefix lifetimes -- that's a good thing! This patch makes the default Preferred Lifetime and Valid Lifetime depend on the Router Lifetime. This helps improve the reaction of SLAAC to renumbering events. See Section 4.1.1 of https://tools.ietf.org/html/draft-gont-6man-slaac-renum-04