### PR TITLE
Be more flexible with unicast client handling

### DIFF
--- a/defaults.h
+++ b/defaults.h
@@ -47,6 +47,7 @@
 #define DFLT_AdvDefaultPreference 0
 #define DFLT_AdvRAMTU RFC2460_MIN_MTU
 #define DFLT_UnicastOnly 0
+#define DFLT_UnrestrictedUnicast 0
 #define DFLT_AdvRASolicitedUnicast 1
 
 /* Options sent with RA */

--- a/gram.y
+++ b/gram.y
@@ -59,6 +59,7 @@
 %token	<dec>	DECIMAL
 %token	<num>	SWITCH
 %token	<addr>	IPV6ADDR
+%token	<addr>	NOT_IPV6ADDR
 %token 		INFINITY
 
 %token		T_IgnoreIfMissing
@@ -363,6 +364,19 @@ v6addrlist_clients	: IPV6ADDR ';'
 			}
 
 			memcpy(&(new->Address), $1, sizeof(struct in6_addr));
+			new->ignored = 0;
+			$$ = new;
+		}
+		| NOT_IPV6ADDR ';'
+		{
+			struct Clients *new = calloc(1, sizeof(struct Clients));
+			if (new == NULL) {
+				flog(LOG_CRIT, "calloc failed: %s", strerror(errno));
+				ABORT;
+			}
+
+			memcpy(&(new->Address), $1, sizeof(struct in6_addr));
+			new->ignored = 1;
 			$$ = new;
 		}
 		| v6addrlist_clients IPV6ADDR ';'
@@ -374,6 +388,20 @@ v6addrlist_clients	: IPV6ADDR ';'
 			}
 
 			memcpy(&(new->Address), $2, sizeof(struct in6_addr));
+			new->ignored = 0;
+			new->next = $1;
+			$$ = new;
+		}
+		| v6addrlist_clients NOT_IPV6ADDR ';'
+		{
+			struct Clients *new = calloc(1, sizeof(struct Clients));
+			if (new == NULL) {
+				flog(LOG_CRIT, "calloc failed: %s", strerror(errno));
+				ABORT;
+			}
+
+			memcpy(&(new->Address), $2, sizeof(struct in6_addr));
+			new->ignored = 1;
 			new->next = $1;
 			$$ = new;
 		}

--- a/gram.y
+++ b/gram.y
@@ -92,6 +92,7 @@
 %token		T_Base6Interface
 %token		T_Base6to4Interface
 %token		T_UnicastOnly
+%token		T_UnrestrictedUnicast
 %token		T_AdvRASolicitedUnicast
 
 %token		T_HomeAgentPreference
@@ -332,6 +333,10 @@ ifaceval	: T_MinRtrAdvInterval NUMBER ';'
 		| T_UnicastOnly SWITCH ';'
 		{
 			iface->UnicastOnly = $2;
+		}
+		| T_UnrestrictedUnicast SWITCH ';'
+		{
+			iface->UnrestrictedUnicast = $2;
 		}
 		| T_AdvRASolicitedUnicast SWITCH ';'
 		{

--- a/interface.c
+++ b/interface.c
@@ -32,6 +32,7 @@ void iface_init_defaults(struct Interface *iface)
 	iface->MinDelayBetweenRAs = DFLT_MinDelayBetweenRAs;
 	iface->MinRtrAdvInterval = -1;
 	iface->UnicastOnly = DFLT_UnicastOnly;
+	iface->UnrestrictedUnicast = DFLT_UnrestrictedUnicast;
 	iface->AdvRASolicitedUnicast = DFLT_AdvRASolicitedUnicast;
 
 	iface->ra_header_info.AdvDefaultPreference = DFLT_AdvDefaultPreference;

--- a/radvd.conf.5.man
+++ b/radvd.conf.5.man
@@ -109,6 +109,8 @@ The definitions are of the form:
 .B };
 .fi
 
+Clients can be prefixed with "!" to ignore them completely and never send advertisements to them.
+
 By default radvd will use the first link-local address for the interface as the
 source address for route advertisements. This can be overwritten by manually
 setting the list of acceptable source addresses. If done, radvd will use the

--- a/radvd.conf.5.man
+++ b/radvd.conf.5.man
@@ -96,7 +96,8 @@ DNSSL (DNS Search List) definitions are of the form:
 By default radvd will send multicast route advertisements so that every node on the link can use them.
 The list of clients (IPv6 address) to advertise to, and accept route solicitations from can be configured.
 If done, radvd does not send send messages to the multicast addresses but
-to the configured unicast addresses only.  Solicitations from other addresses are refused.
+to the configured unicast addresses only.  Solicitations from other addresses are refused unless
+UnrestrictedUnicast is enabled.
 This is similar to UnicastOnly but includes periodic messages and incoming client access
 configuration.  See examples section for a use case of this.
 
@@ -169,6 +170,18 @@ This will prevent unsolicited advertisements from being sent, and
 will cause solicited advertisements to be unicast to the
 soliciting node.  This option is necessary for non-broadcast,
 multiple-access links, such as ISATAP.
+
+Default: off
+
+.TP
+.BR UnrestrictedUnicast " " on | off
+
+A flag indicating whether or not to respond to router
+solicitations when there is a list of clients configured.
+
+This allows regular unsolicited advertisements to be sent
+to some clients without ignoring router solicitations from
+unknown clients.
 
 Default: off
 

--- a/radvd.h
+++ b/radvd.h
@@ -59,6 +59,7 @@ struct Interface {
 	double MinDelayBetweenRAs;
 	int AdvSourceLLAddress;
 	int UnicastOnly;
+	int UnrestrictedUnicast;
 	int AdvRASolicitedUnicast;
 	struct Clients *ClientList;
 

--- a/radvd.h
+++ b/radvd.h
@@ -134,6 +134,7 @@ struct Interface {
 
 struct Clients {
 	struct in6_addr Address;
+	int ignored;
 	struct Clients *next;
 };
 

--- a/scanner.l
+++ b/scanner.l
@@ -79,6 +79,7 @@ AdvHomeAgentFlag	{ return T_AdvHomeAgentFlag; }
 AdvIntervalOpt		{ return T_AdvIntervalOpt; }
 AdvHomeAgentInfo	{ return T_AdvHomeAgentInfo; }
 UnicastOnly		{ return T_UnicastOnly; }
+UnrestrictedUnicast	{ return T_UnrestrictedUnicast; }
 AdvRASolicitedUnicast	{ return T_AdvRASolicitedUnicast; }
 
 Base6Interface		{ return T_Base6Interface; }

--- a/scanner.l
+++ b/scanner.l
@@ -34,6 +34,7 @@ addr1		{hexdigit}{1,4}":"({hexdigit}{1,4}":")*(":"{hexdigit}{1,4})+
 addr2		{hexdigit}{1,4}(":"{hexdigit}{1,4})*"::"
 addr3		({hexdigit}{1,4}":"){7}{hexdigit}{1,4}
 addr		({addr1}|{addr2}|{addr3}|"::")
+naddr		("!"{addr})
 whitespace	([ \t])+
 string		[a-zA-Z0-9`~!@#$%\^&*()_\-+=:\[\]<>,\.?\\]+|L?\"(\\.|[^\\"])*\"
 %%
@@ -123,6 +124,16 @@ Adv6LBRaddress		{ return T_Adv6LBRaddress; }
 
 			yylval.addr = &addr;
 			return IPV6ADDR;
+		}
+
+{naddr}		{
+			static struct in6_addr addr;
+			if (inet_pton(AF_INET6, &yytext[1], &addr) < 1) {
+				return T_BAD_TOKEN;
+			}
+
+			yylval.addr = &addr;
+			return NOT_IPV6ADDR;
 		}
 
 {number}	{

--- a/send.c
+++ b/send.c
@@ -100,6 +100,15 @@ int send_ra_forall(int sock, struct Interface *iface, struct in6_addr *dest)
 		if (dest != NULL && memcmp(dest, &current->Address, sizeof(struct in6_addr)) != 0)
 			continue;
 
+		/* Clients that should be ignored */
+		if (current->ignored) {
+			/* Don't allow fallback to UnrestrictedUnicast for direct queries */
+			if (dest != NULL)
+				return 0;
+
+			continue;
+		}
+
 		send_ra(sock, iface, &(current->Address));
 
 		/* If we should only send the RA to a specific address, we are done */

--- a/send.c
+++ b/send.c
@@ -110,6 +110,11 @@ int send_ra_forall(int sock, struct Interface *iface, struct in6_addr *dest)
 	if (dest == NULL)
 		return 0;
 
+	/* Reply with advertisement to unlisted clients */
+	if (iface->UnrestrictedUnicast) {
+		return send_ra(sock, iface, dest);
+	}
+
 	/* If we refused a client's solicitation, log it if debugging is high enough */
 	if (get_debuglevel() >= 5) {
 		char address_text[INET6_ADDRSTRLEN] = {""};


### PR DESCRIPTION
This adds an `UnrestrictedUnicast` option to allow radvd to respond to unicast solicitations from unknown clients and a `!` prefix to the client address to stop radvd responding to specific clients.

```
        UnicastOnly on;
        UnrestrictedUnicast on; # Unknown clients will receive replies to router solicitations

        clients {
                fe80::1234:56ff:fe78:9abc; # Client that doesn't send its own router solicitations
                !fe80::fedc:baff:fe98:7654; # Client that should not receive router advertisements
        };
```

Config file parsing could probably be better, but `!` is recognised as a string... perhaps an `ignored_clients { }` section or a string suffix like `clients { fe80::fedc:baff:fe98:7654 ignored; }` would be better?