### PR TITLE
Add suport for advertising Captive-Portal API URL (RFC8910)

### DIFF
--- a/defaults.h
+++ b/defaults.h
@@ -222,6 +222,12 @@ struct nd_opt_dnssl_info_local {
 #endif
 #endif
 
+/* Captive Portal RFC 8910 */
+
+#ifndef ND_OPT_CAPTIVE_PORTAL
+#define ND_OPT_CAPTIVE_PORTAL 37
+#endif
+
 /* Configurable values */
 
 #define DFLT_HomeAgentPreference 0

--- a/interface.c
+++ b/interface.c
@@ -429,6 +429,8 @@ static void free_iface_list(struct Interface *iface)
 
 		free(iface->props.if_addrs);
 
+		free(iface->AdvCaptivePortalAPI);
+
 		free(iface);
 		iface = next_iface;
 	}

--- a/radvd.conf.5.man
+++ b/radvd.conf.5.man
@@ -391,6 +391,19 @@ the advertised interval is ( MaxRtrAdvInterval + 20ms ).
 
 Default: off
 
+.TP
+.BR AdvCaptivePortalAPI " " \[dq] URL \[dq]
+
+When set, advertise RFC8908 Captive-Portal API URL.
+
+See RFC8952 Captive Portal Architecture, RFC8910 Captive-Portal
+Identification in DHCP and Router Advertisements (RAs) and
+RFC8908 Captive Portal API for more information.
+
+Most likely you do not need this.
+
+Default: not included
+
 .SH PREFIX SPECIFIC OPTIONS
 
 .TP

--- a/radvd.conf.example
+++ b/radvd.conf.example
@@ -119,6 +119,15 @@ interface lo
                 AdvDNSSLLifetime 30;
         };
 
+#
+# RFC8908 Captive-Portal API URL
+#
+# See RFC8952 Captive Portal Architecture, RFC8910 Captive-Portal
+# Identification in DHCP and Router Advertisements (RAs) and
+# RFC8908 Captive Portal API for more information.
+#
+
+	# AdvCaptivePortal "https://portal.example.net/api/capport.json";
 
 };
 

--- a/radvd.h
+++ b/radvd.h
@@ -60,6 +60,7 @@ struct Interface {
 	int AdvSourceLLAddress;
 	int UnicastOnly;
 	int AdvRASolicitedUnicast;
+	char *AdvCaptivePortalAPI;
 	struct Clients *ClientList;
 
 	struct state_info {

--- a/radvdump.c
+++ b/radvdump.c
@@ -244,6 +244,15 @@ static void print_ff(unsigned char *msg, int len, struct sockaddr_in6 *addr, int
 				printf("\tHomeAgentLifetime %hu;\n", ntohs(ha_info->lifetime));
 			break;
 		}
+		case ND_OPT_CAPTIVE_PORTAL: {
+			char *opt_captive_portal = (char *)opt_str+2;
+			char *captive_portal = strndup(opt_captive_portal, optlen-2);
+
+			printf("\tAdvCaptivePortalAPI \"%s\";\n", captive_portal);
+
+			free(captive_portal);
+			break;
+		}
 		case ND_OPT_TARGET_LINKADDR:
 		case ND_OPT_REDIRECTED_HEADER:
 			flog(LOG_ERR, "invalid option %d in RA", (int)*opt_str);

--- a/scanner.l
+++ b/scanner.l
@@ -80,6 +80,7 @@ AdvIntervalOpt		{ return T_AdvIntervalOpt; }
 AdvHomeAgentInfo	{ return T_AdvHomeAgentInfo; }
 UnicastOnly		{ return T_UnicastOnly; }
 AdvRASolicitedUnicast	{ return T_AdvRASolicitedUnicast; }
+AdvCaptivePortalAPI	{ return T_AdvCaptivePortalAPI; }
 
 Base6Interface		{ return T_Base6Interface; }
 Base6to4Interface	{ return T_Base6to4Interface; }


### PR DESCRIPTION
Adding support for advertising Captive Portal API URL

See RFC8952 Captive Portal Architecture, RFC8910 Captive-Portal Identification in DHCP and Router Advertisements (RAs) and RFC8908 Captive Portal API for more information.

Client side support for this starts with Apple iOS 14 and macOS Big Sur (https://developer.apple.com/news/?id=q78sq5rv), Android 11 for now has only IPv4 DHCP support for this feature, but may implement the router adversisement option in a future update (https://developer.android.com/about/versions/11/features/captive-portal)