### PR TITLE
Update default lifetime for RDNSS & DNSSL per RFC8106

### DIFF
--- a/defaults.h
+++ b/defaults.h
@@ -68,12 +68,30 @@
 #define DFLT_AdvRoutePreference 0 /* medium */
 #define DFLT_RemoveRouteFlag 1
 
-/* RDNSS */
-#define DFLT_AdvRDNSSLifetime(iface) (iface)->MaxRtrAdvInterval
+/* RDNSS
+ * https://tools.ietf.org/html/rfc8106#section-5.1
+ * "The value of Lifetime SHOULD by default be at least 3 * MaxRtrAdvInterval"
+ * RFC8106 does NOT specify bounds
+ *
+ * Note: RFC6106 handled this differently:
+ * https://tools.ietf.org/html/rfc6106#section-5.1
+ * Specifies bounds of MaxRtrAdvInterval <= Lifetime <= 2*MaxRtrAdvInterval
+ * but does NOT specify a default value
+ */
+#define DFLT_AdvRDNSSLifetime(iface) (3 * (iface)->MaxRtrAdvInterval)
 #define DFLT_FlushRDNSSFlag 1
 
-/* DNSSL */
-#define DFLT_AdvDNSSLLifetime(iface) (iface)->MaxRtrAdvInterval
+/* DNSSL
+ * https://tools.ietf.org/html/rfc8106#section-5.2
+ * "Lifetime SHOULD by default be at least 3 * MaxRtrAdvInterval"
+ * RFC8106 does NOT specify bounds
+ *
+ * Note: RFC6106 handled this differently:
+ * https://tools.ietf.org/html/rfc6106#section-5.2
+ * Specifies bounds of MaxRtrAdvInterval <= Lifetime <= 2*MaxRtrAdvInterval
+ * but does NOT specify a default value
+ */
+#define DFLT_AdvDNSSLLifetime(iface) (3 * (iface)->MaxRtrAdvInterval)
 #define DFLT_FlushDNSSLFlag 1
 
 /* Protocol (RFC4861) constants: */

--- a/gram.y
+++ b/gram.y
@@ -707,17 +707,6 @@ rdnssparms	: T_AdvRDNSSPreference NUMBER ';'
 		}
 		| T_AdvRDNSSLifetime number_or_infinity ';'
 		{
-			if ($2 > 2*(iface->MaxRtrAdvInterval))
-				flog(LOG_WARNING, "warning: AdvRDNSSLifetime <= 2*MaxRtrAdvInterval would allow stale DNS servers to be deleted faster");
-			if ($2 < iface->MaxRtrAdvInterval && $2 != 0) {
-				flog(LOG_ERR, "AdvRDNSSLifetime must be at least MaxRtrAdvInterval");
-				rdnss->AdvRDNSSLifetime = iface->MaxRtrAdvInterval;
-			} else {
-				rdnss->AdvRDNSSLifetime = $2;
-			}
-			if ($2 > 2*(iface->MaxRtrAdvInterval))
-				flog(LOG_WARNING, "warning: (%s:%d) AdvRDNSSLifetime <= 2*MaxRtrAdvInterval would allow stale DNS servers to be deleted faster", filename, num_lines);
-
 			rdnss->AdvRDNSSLifetime = $2;
 		}
 		| T_FlushRDNSS SWITCH ';'
@@ -799,14 +788,7 @@ dnsslplist	: dnsslplist dnsslparms
 
 dnsslparms	: T_AdvDNSSLLifetime number_or_infinity ';'
 		{
-			if ($2 > 2*(iface->MaxRtrAdvInterval))
-				flog(LOG_WARNING, "warning: AdvDNSSLLifetime <= 2*MaxRtrAdvInterval would allow stale DNS suffixes to be deleted faster");
-			if ($2 < iface->MaxRtrAdvInterval && $2 != 0) {
-				flog(LOG_ERR, "AdvDNSSLLifetime must be at least MaxRtrAdvInterval");
-				dnssl->AdvDNSSLLifetime = iface->MaxRtrAdvInterval;
-			} else {
-				dnssl->AdvDNSSLLifetime = $2;
-			}
+			dnssl->AdvDNSSLLifetime = $2;
 
 		}
 		| T_FlushDNSSL SWITCH ';'


### PR DESCRIPTION
RFC8106 presents some changes over RFC6106 for the lifetime of RDNSS and
DNSSL.

RFC6106 specified a bound of acceptable values as 'MaxRtrAdvInterval <=
Lifetime <= 2*MaxRtrAdvInterval', and did NOT specify a default value.

RFC8106 removes the bound, and specifies a default value of "at least 3
* MaxRtrAdvInterval"

Reference: https://tools.ietf.org/html/rfc8106#section-5.1
Reference: https://tools.ietf.org/html/rfc6106#section-5.1
Reference: https://tools.ietf.org/html/rfc8106#section-5.2
Reference: https://tools.ietf.org/html/rfc6106#section-5.2
Fixes: https://github.com/radvd-project/radvd/issues/143
Suggested-by: Brandon Jackson <bjackson@napshome.net>
Signed-off-by: Robin H. Johnson <robbat2@gentoo.org>