### PR TITLE
Fix AdvCaptivePortalAPI example config entry.

### DIFF
--- a/radvd.conf.example
+++ b/radvd.conf.example
@@ -127,7 +127,7 @@ interface lo
 # RFC8908 Captive Portal API for more information.
 #
 
-	# AdvCaptivePortal "https://portal.example.net/api/capport.json";
+	# AdvCaptivePortalAPI "https://portal.example.net/api/capport.json";
 
 };
 


### PR DESCRIPTION
While working on the captive portal API support for radvd (PR #141) I first named the new config option AdvCaptivePortal, and then later switched to AdvCaptivePortalAPI - but forgot to also change it in the radvd.conf.example file.

This PR fixes this oversight.

Thanks @andreasschulze for seeing it.
