### PR TITLE
Fixed handling of simultaneous POLLERR and POLLIN

### DIFF
--- a/radvd.c
+++ b/radvd.c
@@ -514,10 +514,10 @@ static struct Interface * main_loop(int sock, struct Interface *ifaces, char con
 
 		if (rc > 0) {
 #ifdef HAVE_NETLINK
-			if (fds[1].revents & (POLLERR | POLLHUP | POLLNVAL)) {
-				flog(LOG_WARNING, "socket error on fds[1].fd");
-			} else if (fds[1].revents & POLLIN) {
+			if (fds[1].revents & POLLIN) {
 				process_netlink_msg(fds[1].fd, ifaces);
+			} else if (fds[1].revents & (POLLERR | POLLHUP | POLLNVAL)) {
+				flog(LOG_WARNING, "socket error on fds[1].fd");
 			}
 #endif
 


### PR DESCRIPTION
In case of receive buffer is filled completely up
Netlink may use combination of POLLER and POLLIN
to indicate this.

In such situation this issue can only be resolved
by reading from the buffer.

We have seen rare cases where radvd actually ends up in a loop, causing high CPU load and flooding syslog like this:
```
Nov 10 10:44:28 router daemon.warn radvd[4289]: socket error on fds[1].fd
Nov 10 10:44:28 router daemon.warn radvd[4289]: socket error on fds[1].fd
Nov 10 10:44:28 router daemon.warn radvd[4289]: socket error on fds[1].fd
Nov 10 10:44:28 router daemon.warn radvd[4289]: socket error on fds[1].fd
Nov 10 10:44:28 router daemon.warn radvd[4289]: socket error on fds[1].fd
Nov 10 10:44:28 router daemon.warn radvd[4289]: socket error on fds[1].fd
Nov 10 10:44:28 router daemon.warn radvd[4289]: socket error on fds[1].fd
Nov 10 10:44:28 router daemon.warn radvd[4289]: socket error on fds[1].fd
Nov 10 10:44:28 router daemon.warn radvd[4289]: socket error on fds[1].fd
Nov 10 10:44:28 router daemon.warn radvd[4289]: socket error on fds[1].fd
Nov 10 10:44:28 router daemon.warn radvd[4289]: socket error on fds[1].fd
Nov 10 10:44:28 router daemon.warn radvd[4289]: socket error on fds[1].fd
Nov 10 10:44:28 router daemon.warn radvd[4289]: socket error on fds[1].fd
Nov 10 10:44:28 router daemon.warn radvd[4289]: socket error on fds[1].fd
```
While strace shows:
```
time([1605001721])                      = 1605001721
send(7, "<28>Nov 10 10:48:41 radvd[4289]:"..., 59, MSG_NOSIGNAL) = 59
gettimeofday({1605001721, 235072}, NULL) = 0
gettimeofday({1605001721, 235323}, NULL) = 0
poll([{fd=6, events=POLLIN}, {fd=5, events=POLLIN}], 2, 1) = 1 ([{fd=5, revents=POLLIN\|POLLERR}])
time([1605001721])                      = 1605001721
send(7, "<28>Nov 10 10:48:41 radvd[4289]:"..., 59, MSG_NOSIGNAL) = 59
gettimeofday({1605001721, 236787}, NULL) = 0
gettimeofday({1605001721, 237033}, NULL) = 0
poll([{fd=6, events=POLLIN}, {fd=5, events=POLLIN}], 2, 1) = 1 ([{fd=5, revents=POLLIN\|POLLERR}])
time([1605001721])                      = 1605001721
send(7, "<28>Nov 10 10:48:41 radvd[4289]:"..., 59, MSG_NOSIGNAL) = 59
gettimeofday({1605001721, 239820}, NULL) = 0
gettimeofday({1605001721, 240457}, NULL) = 0
poll([{fd=6, events=POLLIN}, {fd=5, events=POLLIN}], 2, 1) = 1 ([{fd=5, revents=POLLIN\|POLLERR}])
time([1605001721])                      = 1605001721
send(7, "<28>Nov 10 10:48:41 radvd[4289]:"..., 59, MSG_NOSIGNAL) = 59
gettimeofday({1605001721, 245269}, NULL) = 0
gettimeofday({1605001721, 245521}, NULL) = 0
poll([{fd=6, events=POLLIN}, {fd=5, events=POLLIN}], 2, 1) = 1 ([{fd=5, revents=POLLIN\|POLLERR}])
```