### PR TITLE
Reverts the include.h change in 46883f8a1a02fe42040dd8e48aec0ed871545d4d

### DIFF
--- a/includes.h
+++ b/includes.h
@@ -76,12 +76,7 @@
 #include <sys/sysctl.h>
 #endif
 
-#if !defined(__GLIBC__) && defined(linux)
-#include <linux/if.h>
-#define IF_NAMESIZE IFNAMSIZ
-#else
 #include <net/if.h>
-#endif
 
 #ifdef HAVE_NET_IF_DL_H
 #include <net/if_dl.h>


### PR DESCRIPTION
This has been running fine on my router for over a week.

Closes: #158