### PR TITLE
Fix FreeBSD CI build.

### DIFF
--- a/.github/workflows/bsd.yaml
+++ b/.github/workflows/bsd.yaml
@@ -3,12 +3,12 @@ on: [push, pull_request]
 
 jobs:
   freebsd:
-    runs-on: macos-latest
+    runs-on: macos-10.15
     steps:
     - name: Checkout sources
       uses: actions/checkout@v2
     - name: Build
-      uses: vmactions/freebsd-vm@v0.1.3
+      uses: vmactions/freebsd-vm@v0.1.5
       with:
         run: |
           pkg update


### PR DESCRIPTION
The FreeBSD GitHub action is sticking with macOS 10.15 because the new macOS 11 (that now replaces `macos-latest` image) does not contain the needed VirtualBox software. We will migrate the CI to use the latest macOS image when both the GitHub action and the macOS 11 image are ready.
See actions/virtual-environments#4060 and actions/virtual-environments#4010.