### PR TITLE
Add Option not to Remove Advertisements On Exit 

### DIFF
--- a/defaults.h
+++ b/defaults.h
@@ -49,6 +49,7 @@
 #define DFLT_UnicastOnly 0
 #define DFLT_UnrestrictedUnicast 0
 #define DFLT_AdvRASolicitedUnicast 1
+#define DFLT_RemoveAdvOnExit 1
 
 /* Options sent with RA */
 

--- a/gram.y
+++ b/gram.y
@@ -77,6 +77,7 @@
 %token		T_AdvDefaultLifetime
 %token		T_AdvDefaultPreference
 %token		T_AdvSourceLLAddress
+%token		T_RemoveAdvOnExit
 
 %token		T_AdvOnLink
 %token		T_AdvAutonomous
@@ -307,6 +308,10 @@ ifaceval	: T_MinRtrAdvInterval NUMBER ';'
 		| T_AdvCurHopLimit NUMBER ';'
 		{
 			iface->ra_header_info.AdvCurHopLimit = $2;
+		}
+		| T_RemoveAdvOnExit SWITCH ';'
+		{
+			iface->RemoveAdvOnExit = $2;
 		}
 		| T_AdvSourceLLAddress SWITCH ';'
 		{

--- a/interface.c
+++ b/interface.c
@@ -29,6 +29,7 @@ void iface_init_defaults(struct Interface *iface)
 	iface->AdvSendAdvert = DFLT_AdvSendAdv;
 	iface->MaxRtrAdvInterval = DFLT_MaxRtrAdvInterval;
 	iface->AdvSourceLLAddress = DFLT_AdvSourceLLAddress;
+	iface->RemoveAdvOnExit = DFLT_RemoveAdvOnExit;
 	iface->MinDelayBetweenRAs = DFLT_MinDelayBetweenRAs;
 	iface->MinRtrAdvInterval = -1;
 	iface->UnicastOnly = DFLT_UnicastOnly;

--- a/radvd.c
+++ b/radvd.c
@@ -741,7 +741,7 @@ static void kickoff_adverts(int sock, struct Interface *iface)
 
 static void stop_advert_foo(struct Interface *iface, void *data)
 {
-	if (!iface->UnicastOnly) {
+	if (!iface->UnicastOnly && iface->RemoveAdvOnExit) {
 		/* send a final advertisement with zero Router Lifetime */
 		dlog(LOG_DEBUG, 4, "stopping all adverts on %s", iface->props.name);
 		iface->state_info.cease_adv = 1;

--- a/radvd.conf.5.man
+++ b/radvd.conf.5.man
@@ -339,6 +339,13 @@ included in the RA.
 Default: on
 
 .TP
+.BR RemoveAdvOnExit " " on | off
+
+Upon shutdown, send a final advertisement with zero Router Lifetime. This should cause the router and routes to be immediately removed from the receiving end-nodes' route table. This may need to be disabled ("off") in an vrrp or carp setup.
+
+Default: on
+
+.TP
 .BR AdvHomeAgentFlag " " on | off
 
 When set, indicates that sending router is able to serve as Mobile

--- a/radvd.h
+++ b/radvd.h
@@ -58,6 +58,7 @@ struct Interface {
 	double MinRtrAdvInterval;
 	double MinDelayBetweenRAs;
 	int AdvSourceLLAddress;
+	int RemoveAdvOnExit;
 	int UnicastOnly;
 	int UnrestrictedUnicast;
 	int AdvRASolicitedUnicast;

--- a/scanner.l
+++ b/scanner.l
@@ -67,6 +67,7 @@ AdvCurHopLimit		{ return T_AdvCurHopLimit; }
 AdvDefaultLifetime	{ return T_AdvDefaultLifetime; }
 AdvDefaultPreference	{ return T_AdvDefaultPreference; }
 AdvSourceLLAddress	{ return T_AdvSourceLLAddress; }
+RemoveAdvOnExit		{ return T_RemoveAdvOnExit; }
 
 AdvOnLink		{ return T_AdvOnLink; }
 AdvAutonomous		{ return T_AdvAutonomous; }


### PR DESCRIPTION
Make it configureable if upon shutdown, a final advertisement with zero Router Lifetime is sent . This may need to be disabled ("off") in an vrrp or carp setup to avoid that when restarting on router the clients are disconnected until the next advertisement of the peer router.