### PR TITLE
Secure ND timestamp option support

### DIFF
--- a/defaults.h
+++ b/defaults.h
@@ -252,7 +252,6 @@ struct nd_opt_dnssl_info_local {
 #define ND_OPT_TIMESTAMP 13
 #endif
 
-
 /* Configurable values */
 
 #define DFLT_HomeAgentPreference 0

--- a/defaults.h
+++ b/defaults.h
@@ -247,6 +247,12 @@ struct nd_opt_dnssl_info_local {
 #define ND_OPT_CAPTIVE_PORTAL 37
 #endif
 
+/* Secure ND Timestamp RFC 3971 */
+#ifndef ND_OPT_TIMESTAMP
+#define ND_OPT_TIMESTAMP 13
+#endif
+
+
 /* Configurable values */
 
 #define DFLT_HomeAgentPreference 0

--- a/defaults.h
+++ b/defaults.h
@@ -247,10 +247,15 @@ struct nd_opt_dnssl_info_local {
 #define ND_OPT_CAPTIVE_PORTAL 37
 #endif
 
-/* Secure ND Timestamp RFC 3971 */
+/* TODO Secure ND CGA RFC 3971, 5.1 */
+/* TODO Secure ND RSA Signature RFC 3971, 5.2 */
+
+/* Secure ND Timestamp RFC 3971, 5.3.1 */
 #ifndef ND_OPT_TIMESTAMP
 #define ND_OPT_TIMESTAMP 13
 #endif
+
+/* TODO Secure ND Nonce RFC 3971, 5.3.2 */
 
 /* Configurable values */
 


### PR DESCRIPTION
Add support for Secure ND Timestamp of [RFC 3971](https://datatracker.ietf.org/doc/html/rfc3971#section-5.3) for `radvdump`.

The option is shown as e.g. `AdvTimestamp "1644837356 secs, 32644 fracs";` in the `radvdump` output.