### PR TITLE
add IPV6_DROP_MEMBERSHIP

### DIFF
--- a/device-bsd44.c
+++ b/device-bsd44.c
@@ -139,6 +139,19 @@ int setup_allrouters_membership(int sock, struct Interface *iface)
 	*/
 }
 
+int cleanup_allrouters_membership(int sock, struct Interface *iface)
+{
+	return 0;
+
+	/* Quoting:
+	https://github.com/radvd-project/radvd/issues/145#issuecomment-810466476
+
+	OK, it will be up to FreeBSD guys to show up
+	if they want to upstream their patches.
+
+	*/
+}
+
 int set_interface_linkmtu(const char *iface, uint32_t mtu)
 {
 	dlog(LOG_DEBUG, 4, "setting LinkMTU (%u) for %s is not supported", mtu, iface);

--- a/device-linux.c
+++ b/device-linux.c
@@ -185,6 +185,22 @@ int setup_allrouters_membership(int sock, struct Interface *iface)
 	return 0;
 }
 
+int cleanup_allrouters_membership(int sock, struct Interface *iface)
+{
+	struct ipv6_mreq mreq;
+
+	memset(&mreq, 0, sizeof(mreq));
+	mreq.ipv6mr_interface = iface->props.if_index;
+
+	/* ipv6-allrouters: ff02::2 */
+	mreq.ipv6mr_multiaddr.s6_addr32[0] = htonl(0xFF020000);
+	mreq.ipv6mr_multiaddr.s6_addr32[3] = htonl(0x2);
+
+	setsockopt(sock, SOL_IPV6, IPV6_DROP_MEMBERSHIP, &mreq, sizeof(mreq));
+
+	return 0;
+}
+
 uint32_t get_interface_linkmtu(const char *iface)
 {
 	int value;

--- a/interface.c
+++ b/interface.c
@@ -111,6 +111,12 @@ int setup_iface(int sock, struct Interface *iface)
 	return 0;
 }
 
+int cleanup_iface(int sock, struct Interface *iface)
+{
+	/* leave the allrouters multicast group */
+	cleanup_allrouters_membership(sock, iface);
+	return 0;
+}
 void prefix_init_defaults(struct AdvPrefix *prefix)
 {
 	memset(prefix, 0, sizeof(struct AdvPrefix));

--- a/radvd.h
+++ b/radvd.h
@@ -290,6 +290,7 @@ int set_interface_linkmtu(const char *, uint32_t);
 int set_interface_reachtime(const char *, uint32_t);
 int set_interface_retranstimer(const char *, uint32_t);
 int setup_allrouters_membership(int sock, struct Interface *);
+int cleanup_allrouters_membership(int sock, struct Interface *iface);
 int setup_iface_addrs(struct Interface *);
 int update_device_index(struct Interface *iface);
 int update_device_info(int sock, struct Interface *);
@@ -300,6 +301,7 @@ int get_iface_addrs(char const *name, struct in6_addr *if_addr, /* the first lin
 /* interface.c */
 int check_iface(struct Interface *);
 int setup_iface(int sock, struct Interface *iface);
+int cleanup_iface(int sock, struct Interface *iface);
 struct Interface *find_iface_by_index(struct Interface *iface, int index);
 struct Interface *find_iface_by_name(struct Interface *iface, const char *name);
 struct Interface *find_iface_by_time(struct Interface *iface_list);


### PR DESCRIPTION
Add IPV6_DROP_MEMBERSHIP to clean up resources when reloading or restarting radvd.
Fixes slow kernel memory leak on reload/restart.

Fixes: https://github.com/radvd-project/radvd/issues/177