### PR TITLE
Add pref64 support (RFC8781)

### DIFF
--- a/defaults.h
+++ b/defaults.h
@@ -64,6 +64,9 @@
 #define DFLT_DeprecatePrefixFlag 0
 #define DFLT_DecrementLifetimesFlag 0
 
+/* NAT64 prefix has an associated: */
+#define DFLT_NAT64AdvValidLifetime 65528 /* seconds */
+
 /* Each route has an associated: */
 #define DFLT_AdvRouteLifetime(iface) (3 * (iface)->MaxRtrAdvInterval)
 

--- a/defaults.h
+++ b/defaults.h
@@ -64,8 +64,8 @@
 #define DFLT_DeprecatePrefixFlag 0
 #define DFLT_DecrementLifetimesFlag 0
 
-/* NAT64 prefix has an associated: */
-#define DFLT_NAT64AdvValidLifetime 65528 /* seconds */
+/* RFC8781 section 4.1; this is the non-scaled value (8191 << 3) */
+#define DFLT_NAT64MaxValidLifetime 65528 /* seconds */
 
 /* Each route has an associated: */
 #define DFLT_AdvRouteLifetime(iface) (3 * (iface)->MaxRtrAdvInterval)

--- a/gram.y
+++ b/gram.y
@@ -487,11 +487,11 @@ nat64prefixdef	: nat64prefixhead optional_nat64prefixplist ';'
 		{
 			if (nat64prefix) {
 
-				if (nat64prefix->AdvValidLifetime > 65528)
+				if (nat64prefix->AdvValidLifetime > DFLT_NAT64MaxValidLifetime)
 				{
 					flog(LOG_ERR, "AdvValidLifeTime must be "
-						"smaller or equal to 65528 in %s, line %d",
-						filename, num_lines);
+						"smaller or equal to %d in %s, line %d",
+						DFLT_NAT64MaxValidLifetime, filename, num_lines);
 					ABORT;
 				}
 				nat64prefix->curr_validlft = nat64prefix->AdvValidLifetime;
@@ -506,12 +506,11 @@ nat64prefixhead	: T_NAT64PREFIX IPV6ADDR '/' NUMBER
 			struct in6_addr zeroaddr;
 			memset(&zeroaddr, 0, sizeof(zeroaddr));
 
-#ifndef HAVE_IFADDRS_H	// all-zeros is not a valid for NAT64 prefix
 			if (!memcmp($2, &zeroaddr, sizeof(struct in6_addr))) {
-				flog(LOG_ERR, "invalid all-zeros prefix in %s, line %d", filename, num_lines);
+				flog(LOG_ERR, "invalid all-zeros nat64prefix in %s, line %d", filename, num_lines);
 				ABORT;
 			}
-#endif
+
 			nat64prefix = malloc(sizeof(struct NAT64Prefix));
 
 			if (nat64prefix == NULL) {
@@ -519,32 +518,29 @@ nat64prefixhead	: T_NAT64PREFIX IPV6ADDR '/' NUMBER
 				ABORT;
 			}
 
-			nat64prefix_init_defaults(nat64prefix);
+			nat64prefix_init_defaults(nat64prefix, iface);
 
 			if ($4 > MAX_PrefixLen)
 			{
 				flog(LOG_ERR, "invalid prefix length in %s, line %d", filename, num_lines);
 				ABORT;
 			}
-			if (
-				($4 != 32) &&
-				($4 != 40) &&
-				($4 != 48) &&
-				($4 != 56) &&
-				($4 != 64) &&
-				($4 != 96)
-			) {
+
+			/* RFC8781, section 4: only prefix lengths of 96, 64, 56, 48, 40, and 32 bits are valid */
+			switch ($4) {
+			case 32:
+			case 40:
+			case 48:
+			case 56:
+			case 64:
+			case 96:
+				break;
+			default:
 				flog(LOG_ERR, "only /96, /64, /56, /48, /40 and /32 are allowed for "
-					"NAT64Prefix. %s:%d", filename, num_lines);
+					"nat64prefix in %s:%d", filename, num_lines);
 				ABORT;
 			}
 			nat64prefix->PrefixLen = $4;
-
-			if (3*(iface->MaxRtrAdvInterval) > DFLT_NAT64AdvValidLifetime) {
-				nat64prefix->AdvValidLifetime = DFLT_NAT64AdvValidLifetime;
-			} else {
-				nat64prefix->AdvValidLifetime = 3*(iface->MaxRtrAdvInterval);
-			}
 
 			memcpy(&nat64prefix->Prefix, $2, sizeof(struct in6_addr));
 		}
@@ -561,10 +557,10 @@ nat64prefixplist : nat64prefixplist nat64prefixparms
 
 nat64prefixparms : T_AdvValidLifetime NUMBER ';'
 		{
-			if ($2 > DFLT_NAT64AdvValidLifetime)
+			if ($2 > DFLT_NAT64MaxValidLifetime)
 			{
 				flog(LOG_ERR, "maximum for NAT64 AdvValidLifetime is %d (in %s, line %d)",
-					DFLT_NAT64AdvValidLifetime, filename, num_lines);
+					DFLT_NAT64MaxValidLifetime, filename, num_lines);
 				ABORT;
 			}
 			if (nat64prefix) {

--- a/gram.y
+++ b/gram.y
@@ -528,17 +528,17 @@ nat64prefixhead	: T_NAT64PREFIX IPV6ADDR '/' NUMBER
 
 			/* RFC8781, section 4: only prefix lengths of 96, 64, 56, 48, 40, and 32 bits are valid */
 			switch ($4) {
-				case 32:
-				case 40:
-				case 48:
-				case 56:
-				case 64:
-				case 96:
-					break;
-				default:
-					flog(LOG_ERR, "only /96, /64, /56, /48, /40 and /32 are allowed for "
-							"nat64prefix in %s:%d", filename, num_lines);
-					ABORT;
+			case 32:
+			case 40:
+			case 48:
+			case 56:
+			case 64:
+			case 96:
+				break;
+			default:
+				flog(LOG_ERR, "only /96, /64, /56, /48, /40 and /32 are allowed for "
+						"nat64prefix in %s:%d", filename, num_lines);
+				ABORT;
 			}
 			nat64prefix->PrefixLen = $4;
 

--- a/gram.y
+++ b/gram.y
@@ -487,11 +487,11 @@ nat64prefixdef	: nat64prefixhead optional_nat64prefixplist ';'
 		{
 			if (nat64prefix) {
 
-				if (nat64prefix->AdvValidLifetime > 65528)
+				if (nat64prefix->AdvValidLifetime > DFLT_NAT64MaxValidLifetime)
 				{
 					flog(LOG_ERR, "AdvValidLifeTime must be "
-						"smaller or equal to 65528 in %s, line %d",
-						filename, num_lines);
+						"smaller or equal to %d in %s, line %d",
+						DFLT_NAT64MaxValidLifetime, filename, num_lines);
 					ABORT;
 				}
 				nat64prefix->curr_validlft = nat64prefix->AdvValidLifetime;
@@ -506,12 +506,11 @@ nat64prefixhead	: T_NAT64PREFIX IPV6ADDR '/' NUMBER
 			struct in6_addr zeroaddr;
 			memset(&zeroaddr, 0, sizeof(zeroaddr));
 
-#ifndef HAVE_IFADDRS_H	// all-zeros is not a valid for NAT64 prefix
 			if (!memcmp($2, &zeroaddr, sizeof(struct in6_addr))) {
-				flog(LOG_ERR, "invalid all-zeros prefix in %s, line %d", filename, num_lines);
+				flog(LOG_ERR, "invalid all-zeros nat64prefix in %s, line %d", filename, num_lines);
 				ABORT;
 			}
-#endif
+
 			nat64prefix = malloc(sizeof(struct NAT64Prefix));
 
 			if (nat64prefix == NULL) {
@@ -519,32 +518,29 @@ nat64prefixhead	: T_NAT64PREFIX IPV6ADDR '/' NUMBER
 				ABORT;
 			}
 
-			nat64prefix_init_defaults(nat64prefix);
+			nat64prefix_init_defaults(nat64prefix, iface);
 
 			if ($4 > MAX_PrefixLen)
 			{
 				flog(LOG_ERR, "invalid prefix length in %s, line %d", filename, num_lines);
 				ABORT;
 			}
-			if (
-				($4 != 32) &&
-				($4 != 40) &&
-				($4 != 48) &&
-				($4 != 56) &&
-				($4 != 64) &&
-				($4 != 96)
-			) {
-				flog(LOG_ERR, "only /96, /64, /56, /48, /40 and /32 are allowed for "
-					"NAT64Prefix. %s:%d", filename, num_lines);
-				ABORT;
+
+			/* RFC8781, section 4: only prefix lengths of 96, 64, 56, 48, 40, and 32 bits are valid */
+			switch ($4) {
+				case 32:
+				case 40:
+				case 48:
+				case 56:
+				case 64:
+				case 96:
+					break;
+				default:
+					flog(LOG_ERR, "only /96, /64, /56, /48, /40 and /32 are allowed for "
+							"nat64prefix in %s:%d", filename, num_lines);
+					ABORT;
 			}
 			nat64prefix->PrefixLen = $4;
-
-			if (3*(iface->MaxRtrAdvInterval) > DFLT_NAT64AdvValidLifetime) {
-				nat64prefix->AdvValidLifetime = DFLT_NAT64AdvValidLifetime;
-			} else {
-				nat64prefix->AdvValidLifetime = 3*(iface->MaxRtrAdvInterval);
-			}
 
 			memcpy(&nat64prefix->Prefix, $2, sizeof(struct in6_addr));
 		}
@@ -561,10 +557,10 @@ nat64prefixplist : nat64prefixplist nat64prefixparms
 
 nat64prefixparms : T_AdvValidLifetime NUMBER ';'
 		{
-			if ($2 > DFLT_NAT64AdvValidLifetime)
+			if ($2 > DFLT_NAT64MaxValidLifetime)
 			{
 				flog(LOG_ERR, "maximum for NAT64 AdvValidLifetime is %d (in %s, line %d)",
-					DFLT_NAT64AdvValidLifetime, filename, num_lines);
+					DFLT_NAT64MaxValidLifetime, filename, num_lines);
 				ABORT;
 			}
 			if (nat64prefix) {

--- a/gram.y
+++ b/gram.y
@@ -1,4 +1,4 @@
- /*
+/*
  *
  *   Authors:
  *    Pedro Roque		<roque@di.fc.ul.pt>

--- a/interface.c
+++ b/interface.c
@@ -133,6 +133,16 @@ void prefix_init_defaults(struct AdvPrefix *prefix)
 	prefix->curr_preferredlft = prefix->AdvPreferredLifetime;
 }
 
+void nat64prefix_init_defaults(struct NAT64Prefix *prefix)
+{
+	memset(prefix, 0, sizeof(struct NAT64Prefix));
+
+	// This is the non-scaled value (8191 << 3).
+	prefix->AdvValidLifetime = DFLT_NAT64AdvValidLifetime;
+
+	prefix->curr_validlft = prefix->AdvValidLifetime;
+}
+
 void route_init_defaults(struct AdvRoute *route, struct Interface *iface)
 {
 	memset(route, 0, sizeof(struct AdvRoute));

--- a/interface.c
+++ b/interface.c
@@ -133,12 +133,11 @@ void prefix_init_defaults(struct AdvPrefix *prefix)
 	prefix->curr_preferredlft = prefix->AdvPreferredLifetime;
 }
 
-void nat64prefix_init_defaults(struct NAT64Prefix *prefix)
+void nat64prefix_init_defaults(struct NAT64Prefix *prefix, struct Interface *iface)
 {
 	memset(prefix, 0, sizeof(struct NAT64Prefix));
 
-	// This is the non-scaled value (8191 << 3).
-	prefix->AdvValidLifetime = DFLT_NAT64AdvValidLifetime;
+	prefix->AdvValidLifetime = min(DFLT_NAT64MaxValidLifetime, 3*(iface->MaxRtrAdvInterval));
 
 	prefix->curr_validlft = prefix->AdvValidLifetime;
 }

--- a/process.c
+++ b/process.c
@@ -412,6 +412,9 @@ static void process_ra(struct Interface *iface, unsigned char *msg, int len, str
 			}
 			break;
 		}
+		case ND_OPT_PREF64:
+			/* not checked */
+			break;
 		default:
 			dlog(LOG_DEBUG, 1, "unknown option %d in RA on %s from %s", (int)*opt_str, iface->props.name, addr_str);
 			break;

--- a/radvd.8.man
+++ b/radvd.8.man
@@ -173,4 +173,5 @@ Reuben Hawkins  <reubenhwk@gmail.com>   - current maintainer
 Pierre Ossman   <pierre@ossman.eu>      - RFC6106 (DNSSL) support
 Varka Bhadram 	<varkabhadram@gmail.com> - 6LoWPAN-ND (RFC6775) support
 Robin H. Johnson	<robbat2@gentoo.org>	- RA splitting per RFC 6980 & RFC4861#6.2.3
+Radek Zajic	<radek@zajic.v.pytli.cz>	- NAT64 pref64 support (RFC8781)
 .fi

--- a/radvd.conf.5.man
+++ b/radvd.conf.5.man
@@ -32,6 +32,7 @@ The file contains one or more interface definitions of the form:
 	list of RDNSS definitions
 	list of DNSSL definitions
 	list of ABRO definitions
+	list of NAT64 pref64 definitions
 	list of acceptable RA source addresses
 .B };
 .fi
@@ -130,6 +131,18 @@ ABRO (Authoritative Border Router Option) definitions are of the form:
         list of abro specific options
 .B };
 .fi
+
+NAT64 pref64 (the NAT64 prefix included in the router advertisements):
+
+.nf
+.BR "nat64prefix " prefix / "length " {
+	list of NAT64 prefix specific options
+.B };
+.fi
+
+The value of
+.B length
+can only be one of /32, /40, /48, /56, /64, or /96.
 
 .SH INTERFACE SPECIFIC OPTIONS
 
@@ -627,6 +640,18 @@ A value of all zero bits assumes a default value of 10,000(~one week).
 .BR "AdvVersionLow, AdvVersionHigh " unsigned integer
 Both forms 32-bit unsigned version number corresponding to the set of information contained in RA message.
 
+.SH NAT64 PREF64 SPECIFIC OPTIONS
+
+.TP
+.BR "AdvValidLifetime " seconds ""
+
+The length of time in seconds (relative to the time the packet is
+sent) that the prefix is valid for the purpose of NAT64 existence
+determination. In case the value is not a multiple of 8, the validity
+is rounded up to the next multiple of 8. The maximum is 65528 seconds.
+
+Default: the lesser value of 3 * MaxRtrAdvInterval, or 65528
+
 .SH EXAMPLES
 
 .nf
@@ -746,6 +771,23 @@ interface lowpan0
 	};
 };
 
+The NAT64 pref64 support
+.nf
+interface eth0
+{
+	prefix 2001:db8:100::/64 {
+		AdvOnLink on;
+		AdvAutonomous on;
+		AdvRouterAddr on;
+	};
+	nat64prefix 64:ff9b::/96 {
+		AdvValidLifeTime 1800;
+	};
+	RDNSS 2001:db8:100::64 {
+		AdvRDNSSLifetime 1800;
+	};
+};
+
 .SH FILES
 
 .nf
@@ -798,6 +840,8 @@ RFC 7772, February 2016.
 .PP
 J. Jeong, S. Park, L. Beloeil, and S. Madanapalli, "IPv6 Router Advertisement Options for DNS Configuration",
 RFC 8106, March 2017.
+L. Colitti, and J. Linkova, "Discovering PREF64 in Router Advertisements",
+RFC 8781, April 2020.
 
 .SH "SEE ALSO"
 

--- a/radvd.h
+++ b/radvd.h
@@ -282,7 +282,7 @@ struct nd_opt_6co {
 	struct in6_addr nd_opt_6co_con_prefix;
 }; /*Added by Bhadram */
 
-/* Pref64 option type (rfc8781#section-4) */
+/* Pref64 option type (RFC8781, section 4) */
 #ifndef ND_OPT_PREF64
 #define ND_OPT_PREF64 38
 #endif
@@ -333,7 +333,7 @@ struct Interface *find_iface_by_time(struct Interface *iface_list);
 void dnssl_init_defaults(struct AdvDNSSL *, struct Interface *);
 void for_each_iface(struct Interface *ifaces, void (*foo)(struct Interface *iface, void *), void *data);
 void free_ifaces(struct Interface *ifaces);
-void nat64prefix_init_defaults(struct NAT64Prefix *);
+void nat64prefix_init_defaults(struct NAT64Prefix *, struct Interface *);
 void iface_init_defaults(struct Interface *);
 void prefix_init_defaults(struct AdvPrefix *);
 void rdnss_init_defaults(struct AdvRDNSS *, struct Interface *);

--- a/radvd.h
+++ b/radvd.h
@@ -29,6 +29,7 @@ extern int disableigmp6check;
 #define min(a, b) (((a) < (b)) ? (a) : (b))
 
 struct AdvPrefix;
+struct NAT64Prefix;
 struct Clients;
 
 #define HWADDR_MAX 16
@@ -104,6 +105,8 @@ struct Interface {
 	struct AdvRDNSS *AdvRDNSSList;
 	struct AdvDNSSL *AdvDNSSLList;
 
+	struct NAT64Prefix *NAT64PrefixList;
+
 	uint32_t AdvLinkMTU; /* XXX: sllao also has an if_maxmtu value...Why? */
 	uint32_t AdvRAMTU;   /* MTU used for RA */
 
@@ -164,6 +167,16 @@ struct AdvPrefix {
 	char if6[IFNAMSIZ];
 
 	struct AdvPrefix *next;
+};
+
+struct NAT64Prefix {
+	struct in6_addr Prefix;
+	uint8_t PrefixLen;
+
+	uint32_t AdvValidLifetime;
+	uint32_t curr_validlft;
+
+	struct NAT64Prefix *next;
 };
 
 /* More-Specific Routes extensions */
@@ -269,6 +282,18 @@ struct nd_opt_6co {
 	struct in6_addr nd_opt_6co_con_prefix;
 }; /*Added by Bhadram */
 
+/* Pref64 option type (rfc8781#section-4) */
+#ifndef ND_OPT_PREF64
+#define ND_OPT_PREF64 38
+#endif
+
+struct nd_opt_nat64prefix_info {
+	uint8_t nd_opt_pi_type;
+	uint8_t nd_opt_pi_len;
+	uint16_t nd_opt_pi_lifetime_preflen;
+	unsigned char nd_opt_pi_nat64prefix[12];
+};
+
 /* gram.y */
 struct Interface *readin_config(char const *fname);
 
@@ -308,6 +333,7 @@ struct Interface *find_iface_by_time(struct Interface *iface_list);
 void dnssl_init_defaults(struct AdvDNSSL *, struct Interface *);
 void for_each_iface(struct Interface *ifaces, void (*foo)(struct Interface *iface, void *), void *data);
 void free_ifaces(struct Interface *ifaces);
+void nat64prefix_init_defaults(struct NAT64Prefix *);
 void iface_init_defaults(struct Interface *);
 void prefix_init_defaults(struct AdvPrefix *);
 void rdnss_init_defaults(struct AdvRDNSS *, struct Interface *);

--- a/radvdump.c
+++ b/radvdump.c
@@ -469,6 +469,11 @@ static void print_ff(unsigned char *msg, int len, struct sockaddr_in6 *addr, int
 			break;
 		}
 		case ND_OPT_PREF64: {
+			if (optlen != sizeof(struct nd_opt_nat64prefix_info)) {
+				flog(LOG_ERR, "incorrect pref64 option length in RA from %s, skipping", addr_str);
+				break;
+			}
+
 			struct nd_opt_nat64prefix_info *pinfo = (struct nd_opt_nat64prefix_info *)opt_str;
 			uint16_t lifetime_preflen = ntohs(pinfo->nd_opt_pi_lifetime_preflen);
 			uint8_t prefix_length_code = lifetime_preflen & 7;
@@ -476,7 +481,7 @@ static void print_ff(unsigned char *msg, int len, struct sockaddr_in6 *addr, int
 			int prefix_size = -1;
 			struct in6_addr nat64prefix;
 
-			/* Only copy 96 bits of the prefix */
+			/* The option only contains the first 96 bits of the prefix */
 			memset(&nat64prefix, 0, sizeof(nat64prefix));
 			memcpy(&nat64prefix, &pinfo->nd_opt_pi_nat64prefix, 12);
 			addrtostr(&nat64prefix, prefix_str, sizeof(prefix_str));
@@ -501,7 +506,7 @@ static void print_ff(unsigned char *msg, int len, struct sockaddr_in6 *addr, int
 				prefix_size = 32;
 				break;
 			default:
-				flog(LOG_ERR, "Invalid (reserved) prefix length code %d received", prefix_length_code);
+				flog(LOG_ERR, "Invalid (reserved) nat64prefix length code %d received", prefix_length_code);
 			}
 
 			printf("\n\tnat64prefix %s/%d\n\t{\n", prefix_str, prefix_size);

--- a/radvdump.c
+++ b/radvdump.c
@@ -482,26 +482,26 @@ static void print_ff(unsigned char *msg, int len, struct sockaddr_in6 *addr, int
 			addrtostr(&nat64prefix, prefix_str, sizeof(prefix_str));
 
 			switch (prefix_length_code) {
-				case 0:
-					prefix_size = 96;
-					break;
-				case 1:
-					prefix_size = 64;
-					break;
-				case 2:
-					prefix_size = 56;
-					break;
-				case 3:
-					prefix_size = 48;
-					break;
-				case 4:
-					prefix_size = 40;
-					break;
-				case 5:
-					prefix_size = 32;
-					break;
-				default:
-					flog(LOG_ERR, "Invalid (reserved) prefix length code %d received", prefix_length_code);
+			case 0:
+				prefix_size = 96;
+				break;
+			case 1:
+				prefix_size = 64;
+				break;
+			case 2:
+				prefix_size = 56;
+				break;
+			case 3:
+				prefix_size = 48;
+				break;
+			case 4:
+				prefix_size = 40;
+				break;
+			case 5:
+				prefix_size = 32;
+				break;
+			default:
+				flog(LOG_ERR, "Invalid (reserved) prefix length code %d received", prefix_length_code);
 			}
 
 			printf("\n\tnat64prefix %s/%d\n\t{\n", prefix_str, prefix_size);

--- a/radvdump.c
+++ b/radvdump.c
@@ -285,6 +285,8 @@ static void print_ff(unsigned char *msg, int len, struct sockaddr_in6 *addr, int
 			break;
 		case ND_OPT_DNSSL_INFORMATION:
 			break;
+		case ND_OPT_PREF64:
+			break;
 		default:
 			dlog(LOG_DEBUG, 1, "unknown option %d in RA", (int)*opt_str);
 			break;
@@ -464,6 +466,48 @@ static void print_ff(unsigned char *msg, int len, struct sockaddr_in6 *addr, int
 				printf("\t\tAdvDNSSLLifetime %u;\n", ntohl(dnssl_info->nd_opt_dnssli_lifetime));
 
 			printf("\t}; # End of DNSSL definition\n\n");
+			break;
+		}
+		case ND_OPT_PREF64: {
+			struct nd_opt_nat64prefix_info *pinfo = (struct nd_opt_nat64prefix_info *)opt_str;
+			uint16_t lifetime_preflen = ntohs(pinfo->nd_opt_pi_lifetime_preflen);
+			uint8_t prefix_length_code = lifetime_preflen & 7;
+			uint16_t prefix_lifetime = lifetime_preflen & 0xFFF8;
+			int prefix_size = -1;
+			struct in6_addr nat64prefix;
+
+			/* Only copy 96 bits of the prefix */
+			memset(&nat64prefix, 0, sizeof(nat64prefix));
+			memcpy(&nat64prefix, &pinfo->nd_opt_pi_nat64prefix, 12);
+
+			addrtostr(&nat64prefix, prefix_str, sizeof(prefix_str));
+			switch (prefix_length_code) {
+				case 0:
+					prefix_size = 96;
+					break;
+				case 1:
+					prefix_size = 64;
+					break;
+				case 2:
+					prefix_size = 56;
+					break;
+				case 3:
+					prefix_size = 48;
+					break;
+				case 4:
+					prefix_size = 40;
+					break;
+				case 5:
+					prefix_size = 32;
+					break;
+				default:
+					flog(LOG_ERR, "Invalid (reserved) prefix length code %d received", prefix_length_code);
+			}
+
+			printf("\n\tnat64prefix %s/%d\n\t{\n", prefix_str, prefix_size);
+			printf("\t\tAdvValidLifetime %u;\n", prefix_lifetime);
+			printf("\t}; # End of nat64prefix definition\n\n");
+
 			break;
 		}
 		default:

--- a/radvdump.c
+++ b/radvdump.c
@@ -479,8 +479,8 @@ static void print_ff(unsigned char *msg, int len, struct sockaddr_in6 *addr, int
 			/* Only copy 96 bits of the prefix */
 			memset(&nat64prefix, 0, sizeof(nat64prefix));
 			memcpy(&nat64prefix, &pinfo->nd_opt_pi_nat64prefix, 12);
-
 			addrtostr(&nat64prefix, prefix_str, sizeof(prefix_str));
+
 			switch (prefix_length_code) {
 				case 0:
 					prefix_size = 96;

--- a/scanner.l
+++ b/scanner.l
@@ -51,6 +51,8 @@ DNSSL			{ return T_DNSSL; }
 clients			{ return T_CLIENTS; }
 lowpanco		{ return T_LOWPANCO; }
 abro			{ return T_ABRO; }
+nat64prefix		{ return T_NAT64PREFIX; }
+
 AdvRASrcAddress	{ return T_RASRCADDRESS; }
 
 IgnoreIfMissing		{ return T_IgnoreIfMissing; }

--- a/send.c
+++ b/send.c
@@ -309,24 +309,24 @@ static void add_ra_option_nat64prefix(struct safe_buffer *sb, struct NAT64Prefix
           not set to one of those values.
 	*/
 	switch (prefix->PrefixLen) {
-		case 96:
-			prefix_length_code = 0;
-			break;
-		case 64:
-			prefix_length_code = 1;
-			break;
-		case 56:
-			prefix_length_code = 2;
-			break;
-		case 48:
-			prefix_length_code = 3;
-			break;
-		case 40:
-			prefix_length_code = 4;
-			break;
-		case 32:
-			prefix_length_code = 5;
-			break;
+	case 96:
+		prefix_length_code = 0;
+		break;
+	case 64:
+		prefix_length_code = 1;
+		break;
+	case 56:
+		prefix_length_code = 2;
+		break;
+	case 48:
+		prefix_length_code = 3;
+		break;
+	case 40:
+		prefix_length_code = 4;
+		break;
+	case 32:
+		prefix_length_code = 5;
+		break;
 	}
 
 	/*

--- a/send.c
+++ b/send.c
@@ -803,8 +803,7 @@ static struct safe_buffer_list *build_ra_options(struct Interface const *iface, 
 	}
 
 	if (iface->NAT64PrefixList) {
-		cur =
-		    add_ra_options_nat64prefix(cur, iface->NAT64PrefixList);
+		cur = add_ra_options_nat64prefix(cur, iface->NAT64PrefixList);
 	}
 
 	if (iface->AdvRouteList) {

--- a/send.c
+++ b/send.c
@@ -46,9 +46,7 @@ static void add_ra_option_capport(struct safe_buffer *sb, const char *captive_po
 static struct safe_buffer_list *add_ra_options_prefix(struct safe_buffer_list *sbl, struct Interface const *iface,
 						      char const *ifname, struct AdvPrefix const *prefix, int cease_adv,
 						      struct in6_addr const *dest);
-static struct safe_buffer_list *add_ra_options_nat64prefix(struct safe_buffer_list *sbl, struct Interface const *iface,
-						      char const *ifname, struct NAT64Prefix const *prefix, int cease_adv,
-						      struct in6_addr const *dest);
+static struct safe_buffer_list *add_ra_options_nat64prefix(struct safe_buffer_list *sbl, struct NAT64Prefix const *prefix);
 static struct safe_buffer_list *add_ra_options_route(struct safe_buffer_list *sbl, struct Interface const *iface,
 						     struct AdvRoute const *route, int cease_adv, struct in6_addr const *dest);
 static struct safe_buffer_list *add_ra_options_rdnss(struct safe_buffer_list *sbl, struct Interface const *iface,
@@ -291,7 +289,7 @@ static void limit_prefix_lifetimes(struct AdvPrefix *prefix) {
   }
 }
 
-static void add_ra_option_nat64prefix(struct safe_buffer *sb, struct NAT64Prefix const *prefix, int cease_adv)
+static void add_ra_option_nat64prefix(struct safe_buffer *sb, struct NAT64Prefix const *prefix)
 {
 	struct nd_opt_nat64prefix_info pinfo;
 	uint8_t prefix_length_code = 0;
@@ -442,13 +440,11 @@ static struct safe_buffer_list *add_auto_prefixes(struct safe_buffer_list *sbl, 
 	return sbl;
 }
 
-static struct safe_buffer_list *add_ra_options_nat64prefix(struct safe_buffer_list *sbl, struct Interface const *iface,
-						      char const *ifname, struct NAT64Prefix const *prefix, int cease_adv,
-						      struct in6_addr const *dest)
+static struct safe_buffer_list *add_ra_options_nat64prefix(struct safe_buffer_list *sbl, struct NAT64Prefix const *prefix)
 {
 	while (prefix) {
 		sbl = safe_buffer_list_append(sbl);
-		add_ra_option_nat64prefix(sbl->sb, prefix, cease_adv);
+		add_ra_option_nat64prefix(sbl->sb, prefix);
 
 		prefix = prefix->next;
 	}
@@ -808,7 +804,7 @@ static struct safe_buffer_list *build_ra_options(struct Interface const *iface, 
 
 	if (iface->NAT64PrefixList) {
 		cur =
-		    add_ra_options_nat64prefix(cur, iface, iface->props.name, iface->NAT64PrefixList, iface->state_info.cease_adv, dest);
+		    add_ra_options_nat64prefix(cur, iface->NAT64PrefixList);
 	}
 
 	if (iface->AdvRouteList) {


### PR DESCRIPTION
This pull requests adds support for the `pref64` option, as defined in RFC8781. Its configuration is part of the interface config section and has only two parameters: the `nat64prefix` and the optional `AdvValidLifetime`, the prefix valid lifetime (which should not be smaller than the `MaxRtrAdvInterval`).

```
interface eth0
{
        nat64prefix 64:ff9b::/96
        {
                AdvValidLifetime 1800;
        };
};
```