### PR TITLE
Fix error message for preferred lifetime exceeding valid lifetime

### DIFF
--- a/gram.y
+++ b/gram.y
@@ -576,7 +576,7 @@ prefixdef	: prefixhead optional_prefixplist ';'
 				if (prefix->AdvPreferredLifetime > prefix->AdvValidLifetime)
 				{
 					flog(LOG_ERR, "AdvValidLifeTime must be "
-						"greater than AdvPreferredLifetime in %s, line %d",
+						"greater than or equal to AdvPreferredLifetime in %s, line %d",
 						filename, num_lines);
 					ABORT;
 				}

--- a/interface.c
+++ b/interface.c
@@ -278,7 +278,7 @@ int check_iface(struct Interface *iface)
 
 		if (prefix->AdvPreferredLifetime > prefix->AdvValidLifetime) {
 			flog(LOG_ERR, "AdvValidLifetime for %s (%u) must be "
-				      "greater than AdvPreferredLifetime for",
+				      "greater than or equal to AdvPreferredLifetime for",
 			     iface->props.name, prefix->AdvValidLifetime);
 			res = -1;
 		}


### PR DESCRIPTION
The displayed error message when a prefix's preferred lifetime exceeds it's valid lifetime begins with:

> AdvValidLifeTime must be greater than AdvPreferredLifetime...

this is inconsistent with [RFC 4861 § 4.6.2](https://datatracker.ietf.org/doc/html/rfc4861#section-4.6.2) where the preferred lifetime cannot exceed valid lifetime but can equal it.

The actual code/logic exhibits correct behaviour but the error message is misleading, and has led to at least one incorrect implementation utilizing radvd (VyOS, see relevant implementation error [here](https://github.com/vyos/vyos-1x/blob/332aa77860487398214a10c77d3e6d020f1e68ef/src/conf_mode/service_router-advert.py#L93)).

This PR adds the text "or equal to" to the error message to clarify the true constraint, such that the error now starts with:

> AdvValidLifeTime must be greater than or equal to AdvPreferredLifetime...
