### PR TITLE
CI: Updated the FreeBSD GitHub action to use macOS 12

### DIFF
--- a/.github/workflows/bsd.yaml
+++ b/.github/workflows/bsd.yaml
@@ -3,12 +3,12 @@ on: [push, pull_request]
 
 jobs:
   freebsd:
-    runs-on: macos-10.15
+    runs-on: macos-12
     steps:
     - name: Checkout sources
       uses: actions/checkout@v2
     - name: Build
-      uses: vmactions/freebsd-vm@v0.1.5
+      uses: vmactions/freebsd-vm@v0.2.3
       with:
         run: |
           pkg update


### PR DESCRIPTION
GitHub warned that macOS 10.15 support will be removed at the end of August (see https://github.com/actions/runner-images/issues/5583).