### PR TITLE
Fix case of AdvValidLifetime option

### DIFF
--- a/gram.y
+++ b/gram.y
@@ -489,7 +489,7 @@ nat64prefixdef	: nat64prefixhead optional_nat64prefixplist ';'
 
 				if (nat64prefix->AdvValidLifetime > DFLT_NAT64MaxValidLifetime)
 				{
-					flog(LOG_ERR, "AdvValidLifeTime must be "
+					flog(LOG_ERR, "AdvValidLifetime must be "
 						"smaller or equal to %d in %s, line %d",
 						DFLT_NAT64MaxValidLifetime, filename, num_lines);
 					ABORT;

--- a/radvd.conf.5.man
+++ b/radvd.conf.5.man
@@ -781,7 +781,7 @@ interface eth0
 		AdvRouterAddr on;
 	};
 	nat64prefix 64:ff9b::/96 {
-		AdvValidLifeTime 1800;
+		AdvValidLifetime 1800;
 	};
 	RDNSS 2001:db8:100::64 {
 		AdvRDNSSLifetime 1800;


### PR DESCRIPTION
In the manual page, the NAT64 Lifetime option is presented as
AdvValidLifeTime, while the only accepted input is with lower case T:
AdvValidLifetime.

This fixes the documentation. Please note that there is still some
inconsistency, as ABRO still uses LifeTime with capital T and have it
recognized as a separate token.

Signed-off-by: Ondřej Caletka <ondrej@caletka.cz>