### PR TITLE
Make configuration case insensitive

### DIFF
--- a/gram.y
+++ b/gram.y
@@ -124,7 +124,6 @@
 
 %token		T_AdvVersionLow
 %token		T_AdvVersionHigh
-%token		T_AdvValidLifeTime
 %token		T_Adv6LBRaddress
 
 %token		T_BAD_TOKEN
@@ -489,7 +488,7 @@ nat64prefixdef	: nat64prefixhead optional_nat64prefixplist ';'
 
 				if (nat64prefix->AdvValidLifetime > DFLT_NAT64MaxValidLifetime)
 				{
-					flog(LOG_ERR, "AdvValidLifeTime must be "
+					flog(LOG_ERR, "AdvValidLifetime must be "
 						"smaller or equal to %d in %s, line %d",
 						DFLT_NAT64MaxValidLifetime, filename, num_lines);
 					ABORT;
@@ -575,7 +574,7 @@ prefixdef	: prefixhead optional_prefixplist ';'
 
 				if (prefix->AdvPreferredLifetime > prefix->AdvValidLifetime)
 				{
-					flog(LOG_ERR, "AdvValidLifeTime must be "
+					flog(LOG_ERR, "AdvValidLifetime must be "
 						"greater than or equal to AdvPreferredLifetime in %s, line %d",
 						filename, num_lines);
 					ABORT;
@@ -1031,7 +1030,7 @@ abroparms	: T_AdvVersionLow NUMBER ';'
 		{
 			abro->Version[0] = $2;
 		}
-		| T_AdvValidLifeTime NUMBER ';'
+		| T_AdvValidLifetime NUMBER ';'
 		{
 			abro->ValidLifeTime = $2;
 		}

--- a/radvd.conf.5.man
+++ b/radvd.conf.5.man
@@ -632,7 +632,7 @@ Default: on
 .SH ABRO SPECIFIC OPTIONS
 
 .TP
-.BR "AdvValidLifeTime " seconds
+.BR "AdvValidLifetime " seconds
 The time in units of that the set of border router information is valid.
 A value of all zero bits assumes a default value of 10,000(~one week).
 
@@ -767,7 +767,7 @@ interface lowpan0
 	abro fe80::a200:0:0:1/64 {
 		AdvVersionLow 10;
 		AdvVersionHigh 2;
-		AdvValidLifeTime 2;
+		AdvValidLifetime 2;
 	};
 };
 
@@ -781,7 +781,7 @@ interface eth0
 		AdvRouterAddr on;
 	};
 	nat64prefix 64:ff9b::/96 {
-		AdvValidLifeTime 1800;
+		AdvValidLifetime 1800;
 	};
 	RDNSS 2001:db8:100::64 {
 		AdvRDNSSLifetime 1800;

--- a/radvd.conf.5.man
+++ b/radvd.conf.5.man
@@ -38,7 +38,7 @@ The file contains one or more interface definitions of the form:
 .fi
 
 All the possible interface specific options are detailed below.  Each
-option has to be terminated by a semicolon.
+option has to be terminated by a semicolon. Options are not case sensitive.
 
 Prefix definitions are of the form:
 

--- a/scanner.l
+++ b/scanner.l
@@ -117,7 +117,6 @@ AdvContextPrefix	{ return T_AdvContextPrefix; }
 
 AdvVersionLow		{ return T_AdvVersionLow; }
 AdvVersionHigh		{ return T_AdvVersionHigh; }
-AdvValidLifeTime	{ return T_AdvValidLifeTime; }
 Adv6LBRaddress		{ return T_Adv6LBRaddress; }
 
 {addr}		{

--- a/scanner.l
+++ b/scanner.l
@@ -13,7 +13,7 @@
  *
  */
 
-%option nounput noinput noyywrap yylineno
+%option nounput noinput noyywrap yylineno caseless
 
 %{
 #include "config.h"

--- a/test/test1.conf
+++ b/test/test1.conf
@@ -68,7 +68,7 @@ interface eth0 {
 	abro fe80::a200:0:0:1/64 {
 		AdvVersionLow 10;
 		AdvVersionHigh 2;
-		AdvValidLifeTime 2;
+		AdvValidLifetime 2;
 	};
 };
 


### PR DESCRIPTION
Fixes the issue with `AdvValidLifetime` and `AdvValidLifeTime` depending which section of the configuration you're in, and makes it easier to use.

Closes: https://github.com/radvd-project/radvd/pull/184