### PR TITLE
Add autoignoreprefixes option to interface options

### DIFF
--- a/interface.c
+++ b/interface.c
@@ -436,6 +436,14 @@ static void free_iface_list(struct Interface *iface)
 			dnssl = next_dnssl;
 		}
 
+		struct AutogenIgnorePrefix *ignore_prefixes = iface->IgnorePrefixList;
+		while (ignore_prefixes) {
+			struct AutogenIgnorePrefix *next_ignore_prefix = ignore_prefixes->next;
+
+			free(ignore_prefixes);
+			ignore_prefixes = next_ignore_prefix;
+		}
+
 		struct Clients *clients = iface->ClientList;
 		while (clients) {
 			struct Clients *next_client = clients->next;

--- a/radvd.conf.5.man
+++ b/radvd.conf.5.man
@@ -33,6 +33,7 @@ The file contains one or more interface definitions of the form:
 	list of DNSSL definitions
 	list of ABRO definitions
 	list of NAT64 pref64 definitions
+	list of auto-ignore prefixes
 	list of acceptable RA source addresses
 .B };
 .fi
@@ -56,8 +57,9 @@ Special prefix "::/64" is also supported on systems that implement getifaddrs()
 (on other systems, configuration activation fails and radvd exits).
 When configured, radvd
 picks all non-link-local prefix assigned to the interface and starts advertising
-it.  This may be applicable in non-6to4 scenarios where the upstream prefix might
-change.  This option is incompatible with Base6to4Interface option.
+it (unless ignored with autoignoreprefixes).  This may be applicable in non-6to4
+scenarios where the upstream prefix might change.  This option is incompatible
+with Base6to4Interface option.
 AdvRouterAddr option is always enabled when this configuration is used.
 
 All the possible prefix specific options are described below.  Each
@@ -143,6 +145,18 @@ NAT64 pref64 (the NAT64 prefix included in the router advertisements):
 The value of
 .B length
 can only be one of /32, /40, /48, /56, /64, or /96.
+
+When using the special prefix "::/64" this option forms an ignore list for
+prefixes that should not be automatically generated and advertised. Has no
+effect on any other prefix definition.
+
+The definitions are of the form:
+
+.nf
+.BR autoignoreprefixes " " {
+        list of IPv6 prefixes
+.B };
+.fi
 
 .SH INTERFACE SPECIFIC OPTIONS
 

--- a/radvd.h
+++ b/radvd.h
@@ -30,6 +30,7 @@ extern int disableigmp6check;
 
 struct AdvPrefix;
 struct NAT64Prefix;
+struct AutogenIgnorePrefix;
 struct Clients;
 
 #define HWADDR_MAX 16
@@ -107,6 +108,8 @@ struct Interface {
 
 	struct NAT64Prefix *NAT64PrefixList;
 
+	struct AutogenIgnorePrefix *IgnorePrefixList;
+
 	uint32_t AdvLinkMTU; /* XXX: sllao also has an if_maxmtu value...Why? */
 	uint32_t AdvRAMTU;   /* MTU used for RA */
 
@@ -177,6 +180,13 @@ struct NAT64Prefix {
 	uint32_t curr_validlft;
 
 	struct NAT64Prefix *next;
+};
+
+struct AutogenIgnorePrefix {
+	struct in6_addr Prefix;
+	struct in6_addr Mask;
+
+	struct AutogenIgnorePrefix *next;
 };
 
 /* More-Specific Routes extensions */

--- a/scanner.l
+++ b/scanner.l
@@ -52,6 +52,7 @@ clients			{ return T_CLIENTS; }
 lowpanco		{ return T_LOWPANCO; }
 abro			{ return T_ABRO; }
 nat64prefix		{ return T_NAT64PREFIX; }
+autoignoreprefixes	{ return T_AUTOIGNOREPREFIX; }
 
 AdvRASrcAddress	{ return T_RASRCADDRESS; }
 

--- a/send.c
+++ b/send.c
@@ -415,8 +415,24 @@ static struct safe_buffer_list *add_auto_prefixes(struct safe_buffer_list *sbl, 
 		if (IN6_IS_ADDR_LINKLOCAL(&s6->sin6_addr))
 			continue;
 
+		struct in6_addr prefix6 = get_prefix6(&s6->sin6_addr, &mask->sin6_addr);
+
+		int ignore = 0;
+		for (struct AutogenIgnorePrefix *current = iface->IgnorePrefixList; current; current = current->next) {
+			struct in6_addr candidatePrefix6 = get_prefix6(&current->Prefix, &current->Mask);
+
+			if (memcmp(&prefix6, &candidatePrefix6, sizeof(struct in6_addr)) == 0 &&
+			    memcmp(&mask->sin6_addr, &current->Mask, sizeof(struct in6_addr)) == 0) {
+				ignore = 1;
+				break;
+			}
+		}
+
+		if (ignore)
+			continue;
+
 		xprefix = *prefix;
-		xprefix.Prefix = get_prefix6(&s6->sin6_addr, &mask->sin6_addr);
+		xprefix.Prefix = prefix6;
 		xprefix.PrefixLen = count_mask(mask);
 
 		char pfx_str[INET6_ADDRSTRLEN];


### PR DESCRIPTION
When using the special prefix "::/64" to dynamically generate prefix information via `getifaddrs()` we don't have any control over what prefixes get included without manipulating the addresses present on the interface itself, which is usually not possible to do. Moreover, all generated prefixes share the same prefix-specific options, inhibiting customization of prefix-specific options per-generated prefix.

This new option allows the specification of a prefix ignore list, which functions as a list of prefixes to not automatically add/advertise from the use of the prefix "::/64" definition.

This is useful in cases where an interface has multiple non-link-local addresses but we want radvd to only select certain addresses to generate prefixes from automatically, either because we flat out want to suppress prefix generation from a certain address, or if we want to manually add the prefix definition for that prefix (and thus not rely on auto-generation).

<hr>

As an example, consider an interface `eth0` with the following addresses:

* 2001:db8:123::1/64 (dynamic)
* 2001:db8:1::1/64 (pre-allocated/fixed)
* fde3:ec0f:a4cb::1/64 (ULA, pre-allocated/fixed)

If we wanted to advertise `2001:db8:123::/64` we have no choice but to use the special prefix `::/64` as the prefix is dynamic and we cannot add it directly to the configuration file (without some dynamic script-driven machinery, with it's associated downsides). We can accomplish this by using the following configuration:
```
interface eth0 {
    AdvSendAdvert on;

    prefix ::/64 {
        AdvOnLink on;
        AdvAutonomous on;
    };
};
```
but by doing so we also inadvertently advertise `2001:db8:1::/64` and `fde3:ec0f:a4cb::/64` as well, with the same flags (on-link and autonomous). If we wanted to not advertise one of those addresses, we have no recourse. Similarly, if we wanted to advertise one prefix with different options we cannot do so either.

As a further example, assume we wish to not advertise the autonomous flag for our ULA address, the following configuration will not work:
```
interface eth0 {
    AdvSendAdvert on;

    prefix ::/64 {
        AdvOnLink on;
        AdvAutonomous on;
    };
    prefix fde3:ec0f:a4cb::/64 {
        AdvOnLink on;
        AdvAutonomous off;
    };
};
```
This is because with this configuration radvd will advertise the `fde3:ec0f:a4cb::/64` prefix twice in the same RA, one with autonomous set (as generated from the prefix definition `::/64`) and one with it unset. The end result being that most hosts will see that autonomous is set for `fde3:ec0f:a4cb::/64` and go ahead and generate an address.

<hr>

With the new `autoignoreprefixes` option, we modify the above configuration to be:
```
interface eth0 {
    AdvSendAdvert on;

    autoignoreprefixes {
        2001:db8:1::/64;
        fde3:ec0f:a4cb::/64;
    };

    prefix ::/64 {
        AdvOnLink on;
        AdvAutonomous on;
    };
    prefix fde3:ec0f:a4cb::/64 {
        AdvOnLink on;
        AdvAutonomous off;
    };
};
```
In this case, the `prefix ::/64` definition is suppressed from automatically adding and advertising `2001:db8:1::/64` and `fde3:ec0f:a4cb::/64`, achieving our previous goals of:

1. Flat out suppressing prefix advertisement (`2001:db8:1::/64` is no longer advertised at all).
2. Allowing different options to be set per-prefix (the ULA prefix `fde3:ec0f:a4cb::/64` now gets advertised only once, with autonomous not set).

If we had not added the succeeding `prefix fde3:ec0f:a4cb::/64` section we can also suppress the ULA prefix from being advertised, leaving only the dynamic prefix.

<hr>

Since this is declared as a new option at the interface-level, there is no behaviour change versus before, and existing configurations continue to be valid without modification/migration. The option itself is benign to superfluous prefixes (i.e. extra non-matching prefixes in the list simply do nothing), and the absence of the special prefix definition `::/64` (where it functionally does nothing).