### PR TITLE
this need for android, in deep sleep android sometimes ignore RA.

### DIFF
--- a/defaults.h
+++ b/defaults.h
@@ -137,7 +137,7 @@
 #define MAX_MinRtrAdvInterval(iface) (0.75 * (iface)->MaxRtrAdvInterval)
 
 #define MIN_AdvDefaultLifetime(iface) (MAX2(1, (iface)->MaxRtrAdvInterval))
-#define MAX_AdvDefaultLifetime 9000
+#define MAX_AdvDefaultLifetime 65535
 
 #define MIN_AdvLinkMTU RFC2460_MIN_MTU
 #define MAX_AdvLinkMTU 131072


### PR DESCRIPTION
why maximum 9000 for 2 bytes? android needs maximum because his lost default router with 9000.