### PR TITLE
Increased MAX_AdvDefaultLifetime and MAX_MaxRtrAdvInterval. 

### DIFF
--- a/defaults.h
+++ b/defaults.h
@@ -131,7 +131,7 @@
 /* MAX and MIN (RFC4861), Mobile IPv6 extensions will override if in use */
 
 #define MIN_MaxRtrAdvInterval 4
-#define MAX_MaxRtrAdvInterval 1800
+#define MAX_MaxRtrAdvInterval 65535
 
 #define MIN_MinRtrAdvInterval 3
 #define MAX_MinRtrAdvInterval(iface) (0.75 * (iface)->MaxRtrAdvInterval)

--- a/defaults.h
+++ b/defaults.h
@@ -137,7 +137,7 @@
 #define MAX_MinRtrAdvInterval(iface) (0.75 * (iface)->MaxRtrAdvInterval)
 
 #define MIN_AdvDefaultLifetime(iface) (MAX2(1, (iface)->MaxRtrAdvInterval))
-#define MAX_AdvDefaultLifetime 9000
+#define MAX_AdvDefaultLifetime 65535
 
 #define MIN_AdvLinkMTU RFC2460_MIN_MTU
 #define MAX_AdvLinkMTU 131072


### PR DESCRIPTION
This is proposed in rfc8319 for networks with higher packet loss probabilities or if higher reliability is desired.