### PR TITLE
Makefile.am: drop -Wno-implicit-function-declaration

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -66,9 +66,6 @@ radvd_LDADD = \
 scanner.c: gram.h
 gram.h: gram.c
 
-libradvd_parser_a_CFLAGS = \
-	-Wno-implicit-function-declaration
-
 libradvd_parser_a_SOURCES = \
 	gram.h \
 	gram.y \

--- a/gram.y
+++ b/gram.y
@@ -20,6 +20,10 @@
 
 #define YYERROR_VERBOSE 1
 
+int yylex (void);
+void yyset_in (FILE * _in_str);
+int yylex_destroy (void);
+
 #if 0 /* no longer necessary? */
 #ifndef HAVE_IN6_ADDR_S6_ADDR
 # ifdef __FreeBSD__


### PR DESCRIPTION
1. Clang 16 makes -Wimplicit-function-declaration error by default
   (and it's planned that GCC 14 will do the same) so we need to fix
   the real problem. This is papering over it.

2. It's not true that there's nothing we can do about it. Fix in a follow-up
   commit.

Fixes: b5e6b09
Signed-off-by: Sam James <sam@gentoo.org>