### PR TITLE
CI: update vmactions/freebsd-vm for upstream pytesseract changes

### DIFF
--- a/.github/workflows/bsd.yaml
+++ b/.github/workflows/bsd.yaml
@@ -8,7 +8,7 @@ jobs:
     - name: Checkout sources
       uses: actions/checkout@v2
     - name: Build
-      uses: vmactions/freebsd-vm@v0.2.3
+      uses: vmactions/freebsd-vm@v0.3.0
       with:
         run: |
           pkg update


### PR DESCRIPTION
Signed-off-by: Robin H. Johnson <robbat2@gentoo.org>
Reference: https://github.com/vmactions/freebsd-vm/releases/tag/v0.3.0
Fixes: https://github.com/radvd-project/radvd/issues/197