### PR TITLE
radvd: cleanups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,9 +24,11 @@ tags
 # Build artifacts
 .deps
 *.o
+*.Po
 
 # autotools files
 aclocal.m4
+ar-lib
 autom4te.cache/
 compile
 config.guess
@@ -48,3 +50,5 @@ ylwrap
 # Editor droppings
 *~
 *.swp
+*.rej
+*.orig

--- a/Makefile.am
+++ b/Makefile.am
@@ -113,10 +113,21 @@ radvdump_SOURCES = \
 
 ### coverage ###
 
+if HAVE_CHECK
 cov: check
 	gcov *.c *.h *.l *.y
 	lcov --capture --directory . --output-file coverage.info
 	genhtml coverage.info --output-directory cov
+else
+cov:
+	$(error libcheck not available)
+endif
+
+if HAVE_CHECK
+else
+check:
+	$(error libcheck not available)
+endif
 
 ### man pages ###
 

--- a/configure.ac
+++ b/configure.ac
@@ -60,6 +60,7 @@ AS_IF([test "x$with_check" = "xyes"], [
         PKG_CHECK_MODULES([CHECK], [check >= 0.9.4])
     ])
 ])
+AM_CONDITIONAL(HAVE_CHECK, test x"$with_check" = xyes)
 
 dnl Determine of netlink is available
 AC_MSG_CHECKING(netlink)

--- a/configure.ac
+++ b/configure.ac
@@ -92,6 +92,8 @@ AC_MSG_RESULT(no)
 
 dnl clock_gettime is in librt for glibc <2.17
 AC_SEARCH_LIBS(clock_gettime, rt)
+dnl strlcpy is in libbsd
+AC_SEARCH_LIBS(strlcpy, bsd)
 
 dnl Needed for normal compile
 AC_PROG_INSTALL

--- a/device-bsd44.c
+++ b/device-bsd44.c
@@ -29,8 +29,7 @@ int update_device_info(int sock, struct Interface *iface)
 	struct ifreq ifr;
 
 	memset(&ifr, 0, sizeof(ifr));
-	strncpy(ifr.ifr_name, iface->props.name, IFNAMSIZ - 1);
-	ifr.ifr_name[IFNAMSIZ - 1] = '\0';
+	strlcpy(ifr.ifr_name, iface->props.name, sizeof(ifr.ifr_name));
 
 	if (ioctl(sock, SIOCGIFMTU, &ifr) < 0) {
 		flog(LOG_ERR, "ioctl(SIOCGIFMTU) failed for %s: %s", iface->props.name, strerror(errno));

--- a/device-common.c
+++ b/device-common.c
@@ -22,7 +22,7 @@ int check_device(int sock, struct Interface *iface)
 {
 	struct ifreq ifr;
 	memset(&ifr, 0, sizeof(ifr));
-	strncpy(ifr.ifr_name, iface->props.name, IFNAMSIZ - 1);
+	strlcpy(ifr.ifr_name, iface->props.name, sizeof(ifr.ifr_name));
 
 	if (ioctl(sock, SIOCGIFFLAGS, &ifr) < 0) {
 		flog(LOG_ERR, "ioctl(SIOCGIFFLAGS) failed on %s: %s", iface->props.name, strerror(errno));
@@ -70,8 +70,7 @@ int get_v4addr(const char *ifn, unsigned int *dst)
 
 	struct ifreq ifr;
 	memset(&ifr, 0, sizeof(ifr));
-	strncpy(ifr.ifr_name, ifn, IFNAMSIZ - 1);
-	ifr.ifr_name[IFNAMSIZ - 1] = '\0';
+	strlcpy(ifr.ifr_name, ifn, sizeof(ifr.ifr_name));
 	ifr.ifr_addr.sa_family = AF_INET;
 
 	if (ioctl(fd, SIOCGIFADDR, &ifr) < 0) {

--- a/device-linux.c
+++ b/device-linux.c
@@ -39,7 +39,7 @@ int update_device_info(int sock, struct Interface *iface)
 {
 	struct ifreq ifr;
 	memset(&ifr, 0, sizeof(ifr));
-	strncpy(ifr.ifr_name, iface->props.name, IFNAMSIZ - 1);
+	strlcpy(ifr.ifr_name, iface->props.name, sizeof(ifr.ifr_name));
 
 	if (ioctl(sock, SIOCGIFMTU, &ifr) < 0) {
 		flog(LOG_ERR, "ioctl(SIOCGIFMTU) failed on %s: %s", iface->props.name, strerror(errno));

--- a/gram.y
+++ b/gram.y
@@ -218,8 +218,8 @@ ifacehead	: T_INTERFACE name
 			}
 
 			iface_init_defaults(iface);
-			strncpy(iface->props.name, $2, IFNAMSIZ-1);
-			iface->props.name[IFNAMSIZ-1] = '\0';
+			memset(&iface->props.name, 0, sizeof(iface->props.name));
+			strlcpy(iface->props.name, $2, sizeof(iface->props.name));
 			iface->lineno = num_lines;
 		}
 		;
@@ -689,8 +689,8 @@ prefixparms	: T_AdvOnLink SWITCH ';'
 #else
 			if (prefix) {
 				dlog(LOG_DEBUG, 4, "using prefixes on interface %s for prefixes on interface %s", $2, iface->props.name);
-				strncpy(prefix->if6, $2, IFNAMSIZ-1);
-				prefix->if6[IFNAMSIZ-1] = '\0';
+				memset(&prefix->if6, 0, sizeof(prefix->if6));
+				strlcpy(prefix->if6, $2, sizeof(prefix->if6));
 			}
 #endif
 		}
@@ -703,8 +703,8 @@ prefixparms	: T_AdvOnLink SWITCH ';'
 #else
 			if (prefix) {
 				dlog(LOG_DEBUG, 4, "using interface %s for 6to4 prefixes on interface %s", $2, iface->props.name);
-				strncpy(prefix->if6to4, $2, IFNAMSIZ-1);
-				prefix->if6to4[IFNAMSIZ-1] = '\0';
+				memset(&prefix->if6to4, 0, sizeof(prefix->if6to4));
+				strlcpy(prefix->if6to4, $2, sizeof(prefix->if6to4));
 			}
 #endif
 		}

--- a/includes.h
+++ b/includes.h
@@ -26,6 +26,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#ifndef __FreeBSD__
+#include <bsd/string.h> // strlcpy
+#endif
 #include <syslog.h>
 #include <time.h>
 #include <unistd.h>

--- a/privsep-linux.c
+++ b/privsep-linux.c
@@ -129,7 +129,8 @@ int privsep_interface_linkmtu(const char *iface, uint32_t mtu)
 {
 	struct privsep_command cmd;
 	cmd.type = SET_INTERFACE_LINKMTU;
-	strncpy(cmd.iface, iface, sizeof(cmd.iface));
+	memset(&cmd.iface, 0, sizeof(cmd.iface));
+	strlcpy(cmd.iface, iface, sizeof(cmd.iface));
 	cmd.val = mtu;
 
 	if (writen(pfd, &cmd, sizeof(cmd)) != sizeof(cmd))
@@ -141,7 +142,8 @@ int privsep_interface_curhlim(const char *iface, uint32_t hlim)
 {
 	struct privsep_command cmd;
 	cmd.type = SET_INTERFACE_CURHLIM;
-	strncpy(cmd.iface, iface, sizeof(cmd.iface));
+	memset(&cmd.iface, 0, sizeof(cmd.iface));
+	strlcpy(cmd.iface, iface, sizeof(cmd.iface));
 	cmd.val = hlim;
 	if (writen(pfd, &cmd, sizeof(cmd)) != sizeof(cmd))
 		return -1;
@@ -152,7 +154,8 @@ int privsep_interface_reachtime(const char *iface, uint32_t rtime)
 {
 	struct privsep_command cmd;
 	cmd.type = SET_INTERFACE_REACHTIME;
-	strncpy(cmd.iface, iface, sizeof(cmd.iface));
+	memset(&cmd.iface, 0, sizeof(cmd.iface));
+	strlcpy(cmd.iface, iface, sizeof(cmd.iface));
 	cmd.val = rtime;
 	if (writen(pfd, &cmd, sizeof(cmd)) != sizeof(cmd))
 		return -1;
@@ -163,7 +166,8 @@ int privsep_interface_retranstimer(const char *iface, uint32_t rettimer)
 {
 	struct privsep_command cmd;
 	cmd.type = SET_INTERFACE_RETRANSTIMER;
-	strncpy(cmd.iface, iface, sizeof(cmd.iface));
+	memset(&cmd.iface, 0, sizeof(cmd.iface));
+	strlcpy(cmd.iface, iface, sizeof(cmd.iface));
 	cmd.val = rettimer;
 	if (writen(pfd, &cmd, sizeof(cmd)) != sizeof(cmd))
 		return -1;

--- a/redhat/SysV/radvd.spec.in
+++ b/redhat/SysV/radvd.spec.in
@@ -16,7 +16,9 @@ Requires(postun):   chkconfig, initscripts
 Requires(preun):    chkconfig, initscripts
 Requires(post):     chkconfig
 Requires(pre):      /usr/sbin/useradd
-BuildRequires: flex, byacc
+# SuSE calls it libbsd0, Fedora calls it libbsd
+Requires: libbsd0
+BuildRequires: flex, byacc, libbsd-devel
 BuildRoot:          %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 %description

--- a/redhat/systemd/radvd.spec.in
+++ b/redhat/systemd/radvd.spec.in
@@ -17,8 +17,11 @@ BuildRequires: flex-static
 BuildRequires: pkgconfig
 BuildRequires: check-devel
 BuildRequires: systemd
+BuildRequires: libbsd-devel
 %{?systemd_requires}
 Requires(pre): shadow-utils
+# SuSE calls it libbsd0, Fedora calls it libbsd
+Requires: libbsd0
 
 %description
 radvd is the router advertisement daemon for IPv6.  It listens to router

--- a/test/send.c
+++ b/test/send.c
@@ -3,8 +3,8 @@
 #include <check.h>
 
 /*
- * http://check.sourceforge.net/doc/check_html/check_3.html
- *
+ * https://libcheck.github.io/check/
+ * https://libcheck.github.io/check/doc/check_html/check_3.html
  * http://entrenchant.blogspot.com/2010/08/unit-testing-in-c.html
  */
 

--- a/test/test_build.sh
+++ b/test/test_build.sh
@@ -19,25 +19,26 @@ fi
 # Install the right dependencies according to build host
 echo "Installing required dependencies for distribution '${1}'..."
 case $1 in
+	# watch out, the naming of libbsd vs libbsd0 is not consistent between distros!
 	alpine)
 		apk update
-		apk add alpine-sdk autoconf automake bison check-dev clang flex gettext libtool linux-headers sudo xz
+		apk add alpine-sdk autoconf automake bison check-dev clang flex gettext libtool linux-headers sudo xz libbsd libbsd-dev
 		;;
 	debian)
 		apt update
-		apt install -y autoconf automake bison build-essential check clang flex gettext libtool pkg-config sudo
+		apt install -y autoconf automake bison build-essential check clang flex gettext libtool pkg-config sudo libbsd-dev libbsd0
 		;;
 	fedora)
-		sudo dnf install -y autoconf automake bison check-devel clang flex gettext libtool make pkgconfig xz
+		sudo dnf install -y autoconf automake bison check-devel clang flex gettext libtool make pkgconfig xz libbsd-devel libbsd
 		;;
 	opensuse)
 		zypper refresh
 		zypper --non-interactive install -t pattern devel_C_C++
-		zypper --non-interactive install check-devel clang sudo
+		zypper --non-interactive install check-devel clang sudo libbsd0 libbsd-devel
 		;;
 	ubuntu)
 		sudo apt update
-		sudo apt install -y autoconf automake bison build-essential check clang flex gettext libtool pkg-config
+		sudo apt install -y autoconf automake bison build-essential check clang flex gettext libtool pkg-config libbsd-dev libbsd0
 		;;
 	*)
 		echo "Unsupported distribution, build will be tried without installing any dependencies."

--- a/test/util.c
+++ b/test/util.c
@@ -2,8 +2,8 @@
 #include <check.h>
 
 /*
- * http://check.sourceforge.net/doc/check_html/check_3.html
- *
+ * https://libcheck.github.io/check/
+ * https://libcheck.github.io/check/doc/check_html/check_3.html
  * http://entrenchant.blogspot.com/2010/08/unit-testing-in-c.html
  */
 
@@ -14,7 +14,7 @@ START_TEST(test_safe_buffer)
 	ck_assert_int_eq(0, sb.allocated);
 	ck_assert_int_eq(0, sb.used);
 	ck_assert_int_eq(0, sb.should_free);
-	safe_buffer_free(&sb);
+	// safe_buffer_free(&sb); // Do not free non-malloc'd
 
 	struct safe_buffer *sbptr = new_safe_buffer();
 	ck_assert_ptr_eq(0, sbptr->buffer);
@@ -27,50 +27,50 @@ END_TEST
 
 START_TEST(test_safe_buffer_resize)
 {
-	struct safe_buffer sb = SAFE_BUFFER_INIT;
+	struct safe_buffer *sb = new_safe_buffer();
 	for (int i = 0; i < 5000; i += 17) {
-		safe_buffer_resize(&sb, i);
-		ck_assert_int_ge(sb.allocated, i);
+		safe_buffer_resize(sb, i);
+		ck_assert_int_ge(sb->allocated, i);
 	}
-	safe_buffer_free(&sb);
+	safe_buffer_free(sb);
 }
 END_TEST
 
 START_TEST(test_safe_buffer_append)
 {
-	struct safe_buffer sb = SAFE_BUFFER_INIT;
+	struct safe_buffer *sb = new_safe_buffer();
 	char array[] = {"This is a test"};
-	safe_buffer_append(&sb, array, sizeof(array));
-	ck_assert_str_eq(sb.buffer, array);
-	ck_assert_int_eq(sb.used, sizeof(array));
-	safe_buffer_free(&sb);
+	safe_buffer_append(sb, array, sizeof(array));
+	ck_assert_str_eq(sb->buffer, array);
+	ck_assert_int_eq(sb->used, sizeof(array));
+	safe_buffer_free(sb);
 }
 END_TEST
 
 START_TEST(test_safe_buffer_append2)
 {
-	struct safe_buffer sb = SAFE_BUFFER_INIT;
+	struct safe_buffer *sb = new_safe_buffer();
 	char array[] = {"This is a test"};
-	safe_buffer_append(&sb, array, sizeof(array));
-	safe_buffer_append(&sb, array, sizeof(array));
-	ck_assert_str_eq(sb.buffer, array);
-	ck_assert_str_eq(sb.buffer + sizeof(array), array);
-	ck_assert_int_eq(sb.used, 2 * sizeof(array));
+	safe_buffer_append(sb, array, sizeof(array));
+	safe_buffer_append(sb, array, sizeof(array));
+	ck_assert_str_eq(sb->buffer, array);
+	ck_assert_str_eq(sb->buffer + sizeof(array), array);
+	ck_assert_int_eq(sb->used, 2 * sizeof(array));
 
-	safe_buffer_free(&sb);
+	safe_buffer_free(sb);
 }
 END_TEST
 
 START_TEST(test_safe_buffer_pad)
 {
-	struct safe_buffer sb = SAFE_BUFFER_INIT;
+	struct safe_buffer *sb = new_safe_buffer();
 	char array[] = {"This is a test"};
-	safe_buffer_append(&sb, array, sizeof(array));
-	safe_buffer_pad(&sb, 10);
-	ck_assert_str_eq(sb.buffer, array);
-	ck_assert_int_eq(sb.used, 10 + sizeof(array));
+	safe_buffer_append(sb, array, sizeof(array));
+	safe_buffer_pad(sb, 10);
+	ck_assert_str_eq(sb->buffer, array);
+	ck_assert_int_eq(sb->used, 10 + sizeof(array));
 
-	safe_buffer_free(&sb);
+	safe_buffer_free(sb);
 }
 END_TEST
 
@@ -88,20 +88,20 @@ END_TEST
 START_TEST(test_safe_buffer_list_to_safe_buffer)
 {
 	struct safe_buffer_list *sbl = new_safe_buffer_list();
-	struct safe_buffer sb = SAFE_BUFFER_INIT;
+	struct safe_buffer *sb = new_safe_buffer();
 	char array[] = {"This is a test"};
 
 	safe_buffer_append(sbl->sb, array, sizeof(array));
 	sbl->next = new_safe_buffer_list();
 	safe_buffer_append(sbl->next->sb, array, sizeof(array));
 
-	safe_buffer_list_to_safe_buffer(sbl, &sb);
+	safe_buffer_list_to_safe_buffer(sbl, sb);
 
-	ck_assert_str_eq(sb.buffer, array);
-	ck_assert_str_eq(sb.buffer + sizeof(array), array);
-	ck_assert_int_eq(sb.used, 2 * sizeof(array));
+	ck_assert_str_eq(sb->buffer, array);
+	ck_assert_str_eq(sb->buffer + sizeof(array), array);
+	ck_assert_int_eq(sb->used, 2 * sizeof(array));
 
-	safe_buffer_free(&sb);
+	safe_buffer_free(sb);
 	safe_buffer_list_free(sbl);
 }
 END_TEST

--- a/util.c
+++ b/util.c
@@ -30,12 +30,14 @@ struct safe_buffer *new_safe_buffer(void)
 
 void safe_buffer_free(struct safe_buffer *sb)
 {
-	if (sb->buffer) {
+	if (sb && sb->buffer) {
 		free(sb->buffer);
+		sb->buffer = NULL;
 	}
 
-	if (sb->should_free) {
+	if (sb && sb->should_free) {
 		free(sb);
+		sb = NULL;
 	}
 }
 
@@ -145,8 +147,10 @@ void safe_buffer_list_free(struct safe_buffer_list *sbl)
 {
 	struct safe_buffer_list *next;
 	for (struct safe_buffer_list *current = sbl; current; current = next) {
-		if (current->sb)
+		if (current->sb) {
 			safe_buffer_free(current->sb);
+			current->sb = NULL;
+		}
 		next = current->next;
 		free(current);
 	}


### PR DESCRIPTION
autotools: improve handling when libcheck is absent
Fix -Wstringop-truncation warning: s/strncpy/strlcpy/
test: cleanup testcases for -Wfree-nonheap-object
gitignore: skip newer build/autoconf artifacts & patch droppings

Signed-off-by: Robin H. Johnson <robbat2@gentoo.org>