### PR TITLE
configure.ac: Fix -Wint-conversion warnings

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -178,15 +178,19 @@ AC_HEADER_TIME
 
 dnl Checks for typedefs, structures, and compiler characteristics.
 AC_MSG_CHECKING(whether struct sockaddr_in6 has sin6_scope_id)
-AC_TRY_COMPILE([#include <sys/types.h>
-#include <netinet/in.h>], [static struct sockaddr_in6 ac_sin6; int ac_size = 
-sizeof (ac_sin6.sin6_scope_id);], [AC_MSG_RESULT(yes); AC_DEFINE([HAVE_SIN6_SCOPE_ID],
+AC_TRY_COMPILE([#include <stdint.h>
+#include <sys/types.h>
+#include <netinet/in.h>], [
+static struct sockaddr_in6 ac_sin6;
+uint32_t ac_size = sizeof (ac_sin6.sin6_scope_id);
+], [AC_MSG_RESULT(yes); AC_DEFINE([HAVE_SIN6_SCOPE_ID],
 1, [whether struct sockaddr_in6 has sin6_scope_id])],
 AC_MSG_RESULT(no))
 
 AC_MSG_CHECKING(whether struct in6_addr has u6_addrXX and defines s6_addrXX)
-AC_TRY_COMPILE([#include <netinet/in.h>], [static struct in6_addr in6_u; 
-int u =  in6_u.s6_addr16;], [AC_MSG_RESULT(yes); AC_DEFINE([HAVE_IN6_ADDR_S6_ADDR],
+AC_TRY_COMPILE([#include <stdint.h>
+#include <netinet/in.h>], [static struct in6_addr in6_u;
+uint16_t u =  in6_u.s6_addr16[0];], [AC_MSG_RESULT(yes); AC_DEFINE([HAVE_IN6_ADDR_S6_ADDR],
 1, [whether struct in6_addr has u6_addrXX and defines s6_addrXX])],
 AC_MSG_RESULT(no))
 


### PR DESCRIPTION
These become fatal with Clang 15 and may lead to incorrect configure test results.

```
-ignoreme: warning: incompatible pointer to integer conversion initializing 'int' with an expression of type 'uint16_t[8]' (aka 'unsigned short[8]') [-Wint-conversion]
+ignoreme: error: incompatible pointer to integer conversion initializing 'int' with an expression of type 'uint16_t[8]' (aka 'unsigned short[8]') [-Wint-conversion]
 int u =  in6_u.s6_addr16;
     ^    ~~~~~~~~~~~~~~~
```

Signed-off-by: Sam James <sam@gentoo.org>