### PR TITLE
feat: make it easier to debug why setup_ifaces skipped an interface

### DIFF
--- a/interface.c
+++ b/interface.c
@@ -73,35 +73,35 @@ int setup_iface(int sock, struct Interface *iface)
 
 	/* Check IFF_UP, IFF_RUNNING and IFF_MULTICAST */
 	if (check_device(sock, iface) < 0) {
-		return -1;
+		return -2;
 	}
 
 	/* Set iface->max_mtu and iface hardware address */
 	if (update_device_info(sock, iface) < 0) {
-		return -1;
+		return -3;
 	}
 
 	/* Make sure the settings in the config file for this interface are ok (this depends
 	 * on iface->max_mtu already being set). */
 	if (check_iface(iface) < 0) {
-		return -1;
+		return -4;
 	}
 
 	/* Save the first link local address seen on the specified interface to
 	 * iface->props.if_addr and keep a list off all addrs in iface->props.if_addrs */
 	if (setup_iface_addrs(iface) < 0) {
-		return -1;
+		return -5;
 	}
 
 	/* Check if we a usable RA source address */
 	if (iface->props.if_addr_rasrc == NULL) {
 		dlog(LOG_DEBUG, 5, "no configured AdvRASrcAddress present, skipping send");
-		return -1;
+		return -6;
 	}
 
 	/* join the allrouters multicast group so we get the solicitations */
 	if (setup_allrouters_membership(sock, iface) < 0) {
-		return -1;
+		return -7;
 	}
 
 	iface->state_info.ready = 1;

--- a/radvd.c
+++ b/radvd.c
@@ -766,13 +766,21 @@ static void setup_iface_foo(struct Interface *iface, void *data)
 {
 	int sock = *(int *)data;
 
-	if (setup_iface(sock, iface) < 0) {
+	int setup_iface_result = setup_iface(sock, iface);
+	if (setup_iface_result < 0) {
 		if (iface->IgnoreIfMissing) {
-			dlog(LOG_DEBUG, 4, "interface %s does not exist or is not set up properly, ignoring the interface",
-			     iface->props.name);
+			dlog(LOG_DEBUG, 4,
+					"interface %s does not exist or is not set up properly, ignoring the interface (setup_iface=%d)",
+					iface->props.name,
+					setup_iface_result
+					);
 			return;
 		} else {
-			flog(LOG_ERR, "interface %s does not exist or is not set up properly", iface->props.name);
+			flog(LOG_ERR,
+					"interface %s does not exist or is not set up properly (setup_iface=%d)",
+					iface->props.name,
+					setup_iface_result
+					);
 			exit(1);
 		}
 	}


### PR DESCRIPTION
In debugging why setup_ifaces skips interfaces, use unique return codes and include them in the DEBUG4 output.

Signed-off-by: Robin H. Johnson <robbat2@gentoo.org>