### PR TITLE
Bug fix: Prevent null de-reference when using poll in main_loop

### DIFF
--- a/radvd.c
+++ b/radvd.c
@@ -524,7 +524,9 @@ static struct Interface *main_loop(int sock, struct Interface *ifaces, char cons
 #ifdef HAVE_PPOLL
 		int rc = ppoll(fds, sizeof(fds) / sizeof(fds[0]), tsp, &sigempty);
 #else
-		int rc = poll(fds, sizeof(fds) / sizeof(fds[0]), 1000 * tsp->tv_sec);
+		// tsp could be NULL so check for this
+		int timeout_seconds = tsp != 0 ? 1000 * tsp->tv_sec : 0;
+		int rc = poll(fds, sizeof(fds) / sizeof(fds[0]), timeout_seconds);
 #endif
 
 		if (rc > 0) {


### PR DESCRIPTION
Each loop iteration in main_loop sets the tsp pointer to null. This means tsp is not guaranteed to actually point anywhere valid hence we need to check before using it. This is only applicable if ppoll is missing and no interfaces are found to expire.