### PR TITLE
CI: use improved buildroot images.

### DIFF
--- a/.github/workflows/buildroot.yaml
+++ b/.github/workflows/buildroot.yaml
@@ -12,42 +12,37 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        defconfig_name: [qemu_x86_defconfig, qemu_x86_64_defconfig, raspberrypi4_defconfig, raspberrypi4_64_defconfig, qemu_ppc64le_pseries_defconfig, qemu_mips32r2_malta_defconfig, qemu_mips64_malta_defconfig]
-        libc_name: [glibc, uclibc, musl]
+        defconfig_name:
+          - qemu_x86_defconfig
+          - qemu_x86_64_defconfig
+          - raspberrypi4_defconfig
+          - raspberrypi4_64_defconfig
+          - qemu_ppc64le_pseries_defconfig
+          - qemu_mips32r2_malta_defconfig
+          - qemu_mips64_malta_defconfig
+          - qemu_riscv32_virt_defconfig
+          - qemu_riscv64_virt_defconfig
+        libc_name:
+          - glibc
+          - uclibc
+          - musl
+    env:
+      CI_VERSION: v1.0
+      BUILDROOT_DIRECTORY_NAME: buildroot-${{ matrix.defconfig_name }}-${{ matrix.libc_name }}
     steps:
-      - name: Checkout Buildroot sources
-        # Builroot 2021.02 is the first stable version to natively support radvd 2.19, this avoids a lot of package modifications
-        run: git clone --depth=1 --branch=2021.02 https://git.busybox.net/buildroot
-      - name: Select latest radvd development version
-        working-directory: buildroot/package/radvd
+      - name: Retrieve prebuilt Buildroot image
+        working-directory: /home/runner
         run: |
-          # Do not check for package hash, so there is no need to compute it
-          rm radvd.hash
-          # Get package sources from head of master branch
+          wget https://github.com/radvd-project/radvd-ci/releases/download/${{ env.CI_VERSION }}/${{ env.BUILDROOT_DIRECTORY_NAME }}.tar.zst
+          tar --zstd --strip-components=2 -xf ${{ env.BUILDROOT_DIRECTORY_NAME }}.tar.zst
+      - name: Select the latest radvd upstream version
+        working-directory: /home/runner/${{ env.BUILDROOT_DIRECTORY_NAME }}/package/radvd
+        run: |
+          # Get package sources from head of current branch
           sed -i "/RADVD_VERSION =/c\\RADVD_VERSION = ${GITHUB_SHA}" radvd.mk
-          sed -i '/RADVD_SITE =/c\\RADVD_SITE = https://github.com/radvd-project/radvd' radvd.mk
-          sed -i '9iRADVD_SITE_METHOD = git' radvd.mk
-          # Autotools "configure" script is missing, tell Buildroot to generate it before building
-          sed -i '18iRADVD_AUTORECONF = YES' radvd.mk
-      - name: Enable radvd build
-        working-directory: buildroot
-        run: |
-          echo "BR2_PACKAGE_RADVD=y" >> configs/${{ matrix.defconfig_name }}
-      - name: Select glibc
-        if: ${{ matrix.libc_name == 'glibc' }}
-        working-directory: buildroot
-        run: echo "BR2_TOOLCHAIN_BUILDROOT_GLIBC=y" >> configs/${{ matrix.defconfig_name }}
-      - name: Select uClibc
-        if: ${{ matrix.libc_name == 'uclibc' }}
-        working-directory: buildroot
-        run: echo "BR2_TOOLCHAIN_BUILDROOT_UCLIBC=y" >> configs/${{ matrix.defconfig_name }}
-      - name: Select musl
-        if: ${{ matrix.libc_name == 'musl' }}
-        working-directory: buildroot
-        run: echo "BR2_TOOLCHAIN_BUILDROOT_MUSL=y" >> configs/${{ matrix.defconfig_name }}
-      - name: Configure Buildroot
-        working-directory: buildroot
-        run: make ${{ matrix.defconfig_name }}
+      - name: Trigger a radvd package rebuild
+        working-directory: /home/runner/${{ env.BUILDROOT_DIRECTORY_NAME }}/output/build
+        run: rm -rf radvd*
       - name: Build
-        working-directory: buildroot
+        working-directory: /home/runner/${{ env.BUILDROOT_DIRECTORY_NAME }}
         run: make

--- a/.github/workflows/buildroot.yaml
+++ b/.github/workflows/buildroot.yaml
@@ -1,14 +1,8 @@
 name: Buildroot
-on:
-  workflow_run:
-    workflows: [Linux]
-    types:
-    - completed
+on: [push, pull_request]
 
 jobs:
   buildroot:
-    # Only run this job if the triggering job (Linux) passed
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
The Buildroot CI is working again.
The build speed is greatly improved, going from a total of about 2hours 20min to about 3min 15sec.
Also, the 32-bit and 64-bit RISC-V checks have been introduced.