### PR TITLE
netlink: cleanup interfaces upon removal

### DIFF
--- a/netlink.h
+++ b/netlink.h
@@ -19,6 +19,6 @@
 
 int netlink_get_address_lifetimes(struct AdvPrefix const *prefix, unsigned int *preferred_lft, unsigned int *valid_lft);
 int netlink_get_device_addr_len(struct Interface *iface);
-void process_netlink_msg(int sock, struct Interface *ifaces);
+void process_netlink_msg(int netlink_sock, struct Interface *ifaces, int icmp_sock);
 int netlink_socket(void);
 int prefix_match (struct AdvPrefix const *prefix, struct in6_addr *addr);

--- a/radvd.c
+++ b/radvd.c
@@ -532,7 +532,7 @@ static struct Interface *main_loop(int sock, struct Interface *ifaces, char cons
 		if (rc > 0) {
 #ifdef HAVE_NETLINK
 			if (fds[1].revents & POLLIN) {
-				process_netlink_msg(fds[1].fd, ifaces);
+				process_netlink_msg(fds[1].fd, ifaces, sock);
 			} else if (fds[1].revents & (POLLERR | POLLHUP | POLLNVAL)) {
 				flog(LOG_WARNING, "socket error on fds[1].fd");
 			}


### PR DESCRIPTION
Previously, when an interface was removed radvd did not release it's multicast membership leaking kernel resources leading to a potential out of memory failure of the `setsockopt([...], IPV6_ADD_MEMBERSHIP, [...])` call.

Fixes #228 