### PR TITLE
Also use ubuntu-latest for the FreeBSD build

### DIFF
--- a/.github/workflows/bsd.yaml
+++ b/.github/workflows/bsd.yaml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 
 jobs:
   freebsd:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout sources
       uses: actions/checkout@v4

--- a/.github/workflows/bsd.yaml
+++ b/.github/workflows/bsd.yaml
@@ -8,7 +8,7 @@ jobs:
     - name: Checkout sources
       uses: actions/checkout@v4
     - name: Build
-      uses: vmactions/freebsd-vm@v1.0.2
+      uses: vmactions/freebsd-vm@v1
       with:
         run: |
           pkg update


### PR DESCRIPTION
Let's also use the `ubuntu-latest` run tag for the FreeBSD which is still Ubuntu 22.04, but most likely soon Ubuntu 24.04: https://github.com/actions/runner-images