### PR TITLE
implement setup_allrouters_membership() et al for FreeBSD #145

### DIFF
--- a/device-bsd44.c
+++ b/device-bsd44.c
@@ -127,28 +127,31 @@ ret:
 
 int setup_allrouters_membership(int sock, struct Interface *iface)
 {
+	struct ipv6_mreq mreq;
+
+	memset(&mreq, 0, sizeof(mreq));
+	mreq.ipv6mr_interface = iface->props.if_index;
+
+	/* all-routers multicast address */
+	if (inet_pton(AF_INET6, "ff02::2",
+		    &mreq.ipv6mr_multiaddr.s6_addr) != 1) {
+		flog(LOG_ERR, "inet_pton failed");
+		return -1;
+	}
+
+	if (setsockopt(sock, IPPROTO_IPV6, IPV6_JOIN_GROUP,
+		    &mreq, sizeof(mreq)) < 0 && errno != EADDRINUSE) {
+		flog(LOG_ERR, "can't join ipv6-allrouters on %s", iface->props.name);
+		return -1;
+	}
+
 	return 0;
-
-	/* Quoting:
-	https://github.com/radvd-project/radvd/issues/145#issuecomment-810466476
-
-	OK, it will be up to FreeBSD guys to show up
-	if they want to upstream their patches.
-
-	*/
 }
 
 int cleanup_allrouters_membership(int sock, struct Interface *iface)
 {
+	/* no cleanup necessary */
 	return 0;
-
-	/* Quoting:
-	https://github.com/radvd-project/radvd/issues/145#issuecomment-810466476
-
-	OK, it will be up to FreeBSD guys to show up
-	if they want to upstream their patches.
-
-	*/
 }
 
 int set_interface_linkmtu(const char *iface, uint32_t mtu)
@@ -184,5 +187,5 @@ int check_ip6_forwarding(void)
 int check_ip6_iface_forwarding(const char *iface)
 {
 	dlog(LOG_DEBUG, 4, "checking ipv6 forwarding of interface not supported");
-	return -1;
+	return 1;
 }


### PR DESCRIPTION
This adds the latest FreeBSD ports code modifications.  These went through several iterations over the years due to internal bugs.

This code is specific to FreeBSD.  Mileage may vary for other BSDs and makes no effort to account for this, but should be trivial to achive if required.

Originally submitted by: Geoffrey Sisson <geoff@dns-oarc.net>