### PR TITLE
feat: Support more addresses in RDNSS section

### DIFF
--- a/defaults.h
+++ b/defaults.h
@@ -205,9 +205,7 @@ struct nd_opt_rdnss_info_local {
 	uint8_t nd_opt_rdnssi_len;
 	uint16_t nd_opt_rdnssi_pref_flag_reserved;
 	uint32_t nd_opt_rdnssi_lifetime;
-	struct in6_addr nd_opt_rdnssi_addr1;
-	struct in6_addr nd_opt_rdnssi_addr2;
-	struct in6_addr nd_opt_rdnssi_addr3;
+	struct in6_addr nd_opt_rdnssi_addr[];
 };
 /* pref/flag/reserved field : yyyyx00000000000 (big endian) - 00000000yyyyx000 (little indian); where yyyy = pref, x = flag */
 #if BYTE_ORDER == BIG_ENDIAN

--- a/gram.y
+++ b/gram.y
@@ -847,24 +847,19 @@ rdnssaddr	: IPV6ADDR
 				rdnss_init_defaults(rdnss, iface);
 			}
 
-			switch (rdnss->AdvRDNSSNumber) {
-				case 0:
-					memcpy(&rdnss->AdvRDNSSAddr1, $1, sizeof(struct in6_addr));
-					rdnss->AdvRDNSSNumber++;
-					break;
-				case 1:
-					memcpy(&rdnss->AdvRDNSSAddr2, $1, sizeof(struct in6_addr));
-					rdnss->AdvRDNSSNumber++;
-					break;
-				case 2:
-					memcpy(&rdnss->AdvRDNSSAddr3, $1, sizeof(struct in6_addr));
-					rdnss->AdvRDNSSNumber++;
-					break;
-				default:
-					flog(LOG_CRIT, "too many addresses in RDNSS section");
-					ABORT;
+			rdnss->AdvRDNSSNumber++;
+			if (rdnss->AdvRDNSSNumber > 127) {
+				flog(LOG_CRIT, "Too many RDNSS servers specified - upper limit is 127 based on RDNSSI length field being uint8, RFC8106, section 5.1");
+				ABORT;
 			}
-
+			rdnss->AdvRDNSSAddr =
+				realloc(rdnss->AdvRDNSSAddr,
+					rdnss->AdvRDNSSNumber * sizeof(struct in6_addr));
+			if (rdnss->AdvRDNSSAddr == NULL) {
+				flog(LOG_CRIT, "realloc failed: %s", strerror(errno));
+				ABORT;
+			}
+			memcpy(&rdnss->AdvRDNSSAddr[rdnss->AdvRDNSSNumber - 1], $1, sizeof(struct in6_addr));
 		}
 		;
 
@@ -1127,6 +1122,7 @@ static void cleanup(void)
 	}
 
 	if (rdnss) {
+		free(rdnss->AdvRDNSSAddr);
 		free(rdnss);
 		rdnss = 0;
 	}

--- a/interface.c
+++ b/interface.c
@@ -420,6 +420,7 @@ static void free_iface_list(struct Interface *iface)
 		while (rdnss) {
 			struct AdvRDNSS *next_rdnss = rdnss->next;
 
+			free(rdnss->AdvRDNSSAddr);
 			free(rdnss);
 			rdnss = next_rdnss;
 		}

--- a/process.c
+++ b/process.c
@@ -322,44 +322,23 @@ static void process_ra(struct Interface *iface, unsigned char *msg, int len, str
 			break;
 		case ND_OPT_RDNSS_INFORMATION: {
 			char rdnss_str[INET6_ADDRSTRLEN];
-			struct AdvRDNSS *rdnss = 0;
 			struct nd_opt_rdnss_info_local *rdnssinfo = (struct nd_opt_rdnss_info_local *)opt_str;
 			if (len < sizeof(*rdnssinfo))
 				return;
-			int count = rdnssinfo->nd_opt_rdnssi_len;
 
-			/* Check the RNDSS addresses received */
-			switch (count) {
-			case 7:
-				rdnss = iface->AdvRDNSSList;
-				if (!check_rdnss_presence(rdnss, &rdnssinfo->nd_opt_rdnssi_addr3)) {
-					/* no match found in iface->AdvRDNSSList */
-					addrtostr(&rdnssinfo->nd_opt_rdnssi_addr3, rdnss_str, sizeof(rdnss_str));
-					flog(LOG_WARNING, "RDNSS address %s received on %s from %s is not advertised by us",
-					     rdnss_str, iface->props.name, addr_str);
+			// must be a multiple of 2, in the range of 3..255
+			// https://datatracker.ietf.org/doc/html/rfc8106#section-5.1
+			if (rdnssinfo->nd_opt_rdnssi_len >= 3 && rdnssinfo->nd_opt_rdnssi_len % 2 == 1) {
+				for (int i = 0; i < (rdnssinfo->nd_opt_rdnssi_len - 1) / 2; i++) {
+					if (!check_rdnss_presence(iface->AdvRDNSSList, &rdnssinfo->nd_opt_rdnssi_addr[i])) {
+						addrtostr(&rdnssinfo->nd_opt_rdnssi_addr[i], rdnss_str, sizeof(rdnss_str));
+						flog(LOG_WARNING, "RDNSS address %s received on %s from %s is not advertised by us",
+						     rdnss_str, iface->props.name, addr_str);
+					}
 				}
-			/* FALLTHROUGH */
-			case 5:
-				rdnss = iface->AdvRDNSSList;
-				if (!check_rdnss_presence(rdnss, &rdnssinfo->nd_opt_rdnssi_addr2)) {
-					/* no match found in iface->AdvRDNSSList */
-					addrtostr(&rdnssinfo->nd_opt_rdnssi_addr2, rdnss_str, sizeof(rdnss_str));
-					flog(LOG_WARNING, "RDNSS address %s received on %s from %s is not advertised by us",
-					     rdnss_str, iface->props.name, addr_str);
-				}
-			/* FALLTHROUGH */
-			case 3:
-				rdnss = iface->AdvRDNSSList;
-				if (!check_rdnss_presence(rdnss, &rdnssinfo->nd_opt_rdnssi_addr1)) {
-					/* no match found in iface->AdvRDNSSList */
-					addrtostr(&rdnssinfo->nd_opt_rdnssi_addr1, rdnss_str, sizeof(rdnss_str));
-					flog(LOG_WARNING, "RDNSS address %s received on %s from %s is not advertised by us",
-					     rdnss_str, iface->props.name, addr_str);
-				}
-
-				break;
-			default:
-				flog(LOG_ERR, "invalid len %i in RDNSS option on %s from %s", count, iface->props.name, addr_str);
+			} else {
+				flog(LOG_ERR, "invalid len %i in RDNSS option on %s from %s",
+				     rdnssinfo->nd_opt_rdnssi_len, iface->props.name, addr_str);
 			}
 
 			break;

--- a/radvd.h
+++ b/radvd.h
@@ -208,9 +208,7 @@ struct AdvRDNSS {
 	int AdvRDNSSNumber;
 	uint32_t AdvRDNSSLifetime;
 	int FlushRDNSSFlag;
-	struct in6_addr AdvRDNSSAddr1;
-	struct in6_addr AdvRDNSSAddr2;
-	struct in6_addr AdvRDNSSAddr3;
+	struct in6_addr *AdvRDNSSAddr;
 
 	struct AdvRDNSS *next;
 };

--- a/util.c
+++ b/util.c
@@ -191,10 +191,10 @@ void addrtostr(struct in6_addr const *addr, char *str, size_t str_size)
 int check_rdnss_presence(struct AdvRDNSS *rdnss, struct in6_addr *addr)
 {
 	while (rdnss) {
-		if (!memcmp(&rdnss->AdvRDNSSAddr1, addr, sizeof(struct in6_addr)) ||
-		    !memcmp(&rdnss->AdvRDNSSAddr2, addr, sizeof(struct in6_addr)) ||
-		    !memcmp(&rdnss->AdvRDNSSAddr3, addr, sizeof(struct in6_addr)))
-			return 1; /* rdnss address found in the list */
+		for (int i = 0; i < rdnss->AdvRDNSSNumber; i++) {
+			if (!memcmp(&rdnss->AdvRDNSSAddr[i], addr, sizeof(struct in6_addr)))
+				return 1; /* rdnss address found in the list */
+		}
 		rdnss = rdnss->next;
 	}
 	return 0;


### PR DESCRIPTION
This is based on PR#193, with significant cleanups & safety checks added.

- RFC 6106 section 5.3.1 recommended that the number of RDNSS addresses should be limited to three, however that was for clients, not servers.
- RFC 8106 section 5.3.1 clarified the recommendation to at least 3 from multiple sources.

Based on this, set the limit for a single RDNSS section to 127 servers in radvd, based on the size of the length field. Note that it may cause fragmentation as the single option exceeds usable RA option space (MTU less headers); and server configurations should generally use fewer.

See also the RFC6106 errata & RFC6980 section 2 for behaviors of very large RA options.

Reference: https://www.rfc-editor.org/errata/rfc6106
Reference: https://datatracker.ietf.org/doc/html/rfc6980#section-2
Reference: https://datatracker.ietf.org/doc/html/rfc6106#section-5.3.1
Reference: https://datatracker.ietf.org/doc/html/rfc8106#section-5.3.1
Based-on: https://github.com/radvd-project/radvd/pull/193
Based-on-work-by: WenChao1Hou <wenchao.hou@outlook.com>