### PR TITLE
fix: ensure send_ra_forall racount only increments for non-unicast

### DIFF
--- a/radvd.h
+++ b/radvd.h
@@ -71,7 +71,7 @@ struct Interface {
 		int ready;   /* Info whether this interface has been initialized successfully */
 		int changed; /* Info whether this interface's settings have changed */
 		int cease_adv;
-		uint32_t racount;
+		uint32_t racount; // count of non-unicast initial router adv
 	} state_info;
 
 	struct properties {

--- a/send.c
+++ b/send.c
@@ -88,7 +88,12 @@ int send_ra_forall(int sock, struct Interface *iface, struct in6_addr *dest)
 		return -1;
 	}
 
-	if (iface->state_info.racount < MAX_INITIAL_RTR_ADVERTISEMENTS)
+	// Ignore unicast request/response - otherwise rapid unicast
+	// requests during startup can cause multicast/broadcast RAs to *NOT* be
+	// sent on the desired schedule.
+	// racount is consumed in interface.c to calculate when to send the
+	// next non-unicast RA.
+	if (iface->state_info.racount < MAX_INITIAL_RTR_ADVERTISEMENTS && dest == NULL)
 		iface->state_info.racount++;
 
 	/* If no list of clients was specified for this interface, we broadcast */


### PR DESCRIPTION
Ignore unicast request/response for racount - otherwise rapid unicast requests during startup can cause multicast/broadcast RAs to *NOT* be sent to the desired schedule.

racount is consumed in interface.c to calculate when to send the next non-unicast RA.


Closes: https://github.com/radvd-project/radvd/issues/173