### PR TITLE
Update Installation instructions and make it compile on MacOS.

### DIFF
--- a/README
+++ b/README
@@ -2,6 +2,10 @@
 Installation:
 =============
 
+Run the autoconf process in a Docker container, as follows:
+
+./autogen-container.sh
+
 Run configure, e.g.
 
 ./configure --prefix=/usr/local --sysconfdir=/etc --mandir=/usr/share/man

--- a/includes.h
+++ b/includes.h
@@ -26,7 +26,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#ifndef __FreeBSD__
+#if !defined(__FreeBSD__) && !defined(__APPLE__)
 #include <bsd/string.h> // strlcpy
 #endif
 #include <syslog.h>


### PR DESCRIPTION
MacOS includes strlcpy in the standard string.h like FreeBSD.
The README file, not having been updated for a decade or so, didn't cover running autoconf tools in a container.