### PR TITLE
Avoid libbsd header with libc strlcpy

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -103,7 +103,7 @@ AC_MSG_RESULT(no)
 dnl clock_gettime is in librt for glibc <2.17
 AC_SEARCH_LIBS(clock_gettime, rt)
 
-AC_CHECK_FUNC(strlcpy, found_strlcpy=yes, found_strlcpy=no)
+AC_CHECK_FUNCS(strlcpy, found_strlcpy=yes, found_strlcpy=no)
 if test "x$found_strlcpy" = xno; then
 	dnl check libbsd for strlcpy
 	PKG_CHECK_MODULES([BSD], [libbsd >= 0])

--- a/includes.h
+++ b/includes.h
@@ -26,7 +26,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#ifndef __FreeBSD__
+#ifndef HAVE_STRLCPY
 #include <bsd/string.h> // strlcpy
 #endif
 #include <syslog.h>


### PR DESCRIPTION
While #256 avoided the libbsd library dependency, this avoids the header requirement except when libbsd is actually needed.
