### PR TITLE
RFC8319 support: Increase max AdvDefaultLifetime and MaxRtrAdvInterval

### DIFF
--- a/defaults.h
+++ b/defaults.h
@@ -128,16 +128,16 @@
 #define MIN_RANDOM_FACTOR (1.0 / 2.0)
 #define MAX_RANDOM_FACTOR (3.0 / 2.0)
 
-/* MAX and MIN (RFC4861), Mobile IPv6 extensions will override if in use */
+/* MAX and MIN (RFC4861 and RFC8316), Mobile IPv6 extensions will override if in use */
 
 #define MIN_MaxRtrAdvInterval 4
-#define MAX_MaxRtrAdvInterval 1800
+#define MAX_MaxRtrAdvInterval 65535 /* respecting RFC8316 Section 4 */
 
 #define MIN_MinRtrAdvInterval 3
 #define MAX_MinRtrAdvInterval(iface) (0.75 * (iface)->MaxRtrAdvInterval)
 
 #define MIN_AdvDefaultLifetime(iface) (MAX2(1, (iface)->MaxRtrAdvInterval))
-#define MAX_AdvDefaultLifetime 9000
+#define MAX_AdvDefaultLifetime 65535 /* respecting RFC8316 Section 4 */
 
 #define MIN_AdvLinkMTU RFC2460_MIN_MTU
 #define MAX_AdvLinkMTU 131072

--- a/radvd.conf.5.man
+++ b/radvd.conf.5.man
@@ -243,7 +243,7 @@ Default: on
 The maximum time allowed between sending unsolicited multicast
 router advertisements from the interface, in seconds.
 
-Must be no less than 4 seconds and no greater than 1800 seconds.
+Must be no less than 4 seconds and no greater than 65535 seconds.
 
 Minimum when using Mobile IPv6 extensions: 0.07.
 
@@ -355,7 +355,7 @@ information contained in other message fields or options.  Options
 that need time limits for their information include their own
 lifetime fields.
 
-Must be either zero or between MaxRtrAdvInterval and 9000 seconds.
+Must be either zero or between MaxRtrAdvInterval and 65535 seconds.
 
 Default: 3 * MaxRtrAdvInterval (Minimum 1 second).
 


### PR DESCRIPTION
I stumbled upon the past pull request #192 which seem to have been closed without no particular reason so I wanted to have another go at maybe getting this fixed because I'm running into the exact same issue as #190. 

The original limits for the two parameters AdvDefaultLifetime and MaxRtrAdvInterval that are present in radvd right now (9000 and 1800) were defined in RFC 4861 from September 2007. However there's a newer RFC, RFC 8319, from February 2018 that updates the previous RFC and defines that these two particular limits be increased - quoting from RFC 8319: 

>  Updates to RFC 4861
>
>   This document updates Sections 4.2 and 6.2.1 of [RFC4861] to change the following router configuration variables.
>
>   In Section 4.2, inside the paragraph that defines Router Lifetime, change 9000 to 65535 seconds.
>
>   In Section 6.2.1, inside the paragraph that defines MaxRtrAdvInterval, change 1800 to 65535 seconds.
>
>   In Section 6.2.1, inside the paragraph that defines AdvDefaultLifetime, change 9000 to 65535 seconds.

The past two PRs did already mention that this is a change that's requested by RFC8319 and included this exact quote and still they were closed with a message like "there's no proper justification for why this limit is changed", which I don't quite understand - they quoted the relevant part from the RFC?

Is there anything else that's needed to get radvd compliant with the new limits that have now been defined in RFC8319 for over 7 years now? Since these two constants don't change runtime behavior per-se but just allow the administrator to configure higher limits than before, this change shouldn't break any current setups.