### PR TITLE
ci: recent fedora needs awk

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -63,6 +63,9 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
+      - name: Install build dependency
+        run: |
+          dnf install --assumeyes awk
       - name: Build
         env:
           CC: ${{ matrix.compiler }}


### PR DESCRIPTION
Fedora 42 doesn't have `awk` anymore.
Install it early in the build pipeline.