### PR TITLE
build: drop ubuntu20.04 due to EOL

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -104,7 +104,7 @@ jobs:
   ubuntu:
     strategy:
       matrix:
-        ubuntu_version: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04]
+        ubuntu_version: [ubuntu-22.04, ubuntu-24.04]
         compiler: [clang, gcc]
     runs-on: ${{ matrix.ubuntu_version }}
     steps:

--- a/Docker.autogen
+++ b/Docker.autogen
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 # apt is meant to be used by humans, whereas apt-get is for scripting.
 RUN apt-get update && \
 	DEBIAN_FRONTEND=noninteractive apt-get install -qy \

--- a/configure.ac
+++ b/configure.ac
@@ -133,7 +133,7 @@ fi
 dnl Not needed
 AC_PATH_PROG(LN, ln)
 AC_PROG_YACC
-AM_PROG_LEX # add (noyywrap) after ubuntu 20.04 is no longer supported
+AM_PROG_LEX(noyywrap)
 AC_PATH_PROG(TAR, tar)
 AC_PATH_PROG(GZIP, gzip)
 


### PR DESCRIPTION
Signed-off-by: Robin H. Johnson <robbat2@gentoo.org>
Reference: https://github.com/actions/runner-images/issues/11101