### PR TITLE
Add AdvSNACRouterFlag option to set the SNAC router bit

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,5 @@
+2025/05/19 Add AdvSNACRouterFlag <Kimmo Kulovesi>
+
 2024/12/31  Release v2.20
 	build: annotated/signed tags need a tweak to verify correctly
 	build: need awk for newer autoconf

--- a/defaults.h
+++ b/defaults.h
@@ -168,6 +168,8 @@
 #define DFLT_AdvIntervalOpt 0
 #define DFLT_AdvHomeAgentInfo 0
 
+#define DFLT_AdvSNACRouterFlag 0
+
 /* Option types (defined also at least in glibc 2.2's netinet/icmp6.h) */
 
 #ifndef ND_OPT_RTR_ADV_INTERVAL
@@ -241,6 +243,9 @@ struct nd_opt_dnssl_info_local {
 #else
 #define ND_OPT_RDNSSI_FLAG_S 0x0008
 #endif
+#endif
+#ifndef ND_RA_FLAG_SNAC_ROUTER
+#define ND_RA_FLAG_SNAC_ROUTER 0x02
 #endif
 
 /* Captive Portal RFC 8910 */

--- a/gram.y
+++ b/gram.y
@@ -96,6 +96,7 @@ int yylex_destroy (void);
 %token		T_AdvHomeAgentFlag
 %token		T_AdvIntervalOpt
 %token		T_AdvHomeAgentInfo
+%token          T_AdvSNACRouterFlag
 
 %token		T_Base6Interface
 %token		T_Base6to4Interface
@@ -348,6 +349,10 @@ ifaceval	: T_MinRtrAdvInterval NUMBER ';'
 		| T_HomeAgentLifetime NUMBER ';'
 		{
 			iface->mipv6.HomeAgentLifetime = $2;
+		}
+		| T_AdvSNACRouterFlag SWITCH ';'
+		{
+			iface->ra_header_info.AdvSNACRouterFlag = $2;
 		}
 		| T_UnicastOnly SWITCH ';'
 		{

--- a/interface.c
+++ b/interface.c
@@ -42,6 +42,7 @@ void iface_init_defaults(struct Interface *iface)
 	iface->ra_header_info.AdvRetransTimer = DFLT_AdvRetransTimer;
 	iface->ra_header_info.AdvCurHopLimit = DFLT_AdvCurHopLimit;
 	iface->ra_header_info.AdvHomeAgentFlag = DFLT_AdvHomeAgentFlag;
+	iface->ra_header_info.AdvSNACRouterFlag = DFLT_AdvSNACRouterFlag;
 
 	iface->mipv6.AdvIntervalOpt = DFLT_AdvIntervalOpt;
 	iface->mipv6.AdvHomeAgentInfo = DFLT_AdvHomeAgentInfo;

--- a/radvd.conf.5.man
+++ b/radvd.conf.5.man
@@ -529,6 +529,14 @@ Note: RFC4861's suggested default value is significantly longer: 7 days.
 Default: 14400 seconds (4 hours)
 
 .TP
+.BR AdvSNACRouterFlag " " on | off
+
+When set, indicates the router is a SNAC router (stub network auto
+configuration, e.g., for IPv6-only stub networks).
+
+Default: off
+
+.TP
 .BR DeprecatePrefix " " on | off
 
 Upon shutdown, this option will cause radvd to deprecate the prefix by announcing it in the radvd shutdown RA with a zero preferred lifetime and a valid lifetime slightly greater than 2 hours. This will encourage end-nodes using this prefix to deprecate any associated addresses immediately. Note that this option should only be used when only one router is announcing the prefix onto the link, otherwise end-nodes will deprecate associated addresses despite the prefix still being valid for preferred use.

--- a/radvd.h
+++ b/radvd.h
@@ -89,7 +89,7 @@ struct Interface {
 		int AdvOtherConfigFlag;
 		uint8_t AdvCurHopLimit;
 		int AdvHomeAgentFlag;
-        int AdvSNACRouterFlag;
+		int AdvSNACRouterFlag;
 		int32_t AdvDefaultLifetime; /* XXX: really uint16_t but we need to use -1 */
 		int AdvDefaultPreference;
 		uint32_t AdvReachableTime;

--- a/radvd.h
+++ b/radvd.h
@@ -89,6 +89,7 @@ struct Interface {
 		int AdvOtherConfigFlag;
 		uint8_t AdvCurHopLimit;
 		int AdvHomeAgentFlag;
+        int AdvSNACRouterFlag;
 		int32_t AdvDefaultLifetime; /* XXX: really uint16_t but we need to use -1 */
 		int AdvDefaultPreference;
 		uint32_t AdvReachableTime;

--- a/radvdump.c
+++ b/radvdump.c
@@ -177,6 +177,9 @@ static void print_ff(unsigned char *msg, int len, struct sockaddr_in6 *addr, int
 	if (!edefs || DFLT_AdvHomeAgentFlag != (ND_RA_FLAG_HOME_AGENT == (radvert->nd_ra_flags_reserved & ND_RA_FLAG_HOME_AGENT)))
 		printf("\tAdvHomeAgentFlag %s;\n", (radvert->nd_ra_flags_reserved & ND_RA_FLAG_HOME_AGENT) ? "on" : "off");
 
+	if (!edefs || DFLT_AdvHomeAgentFlag != (ND_RA_FLAG_SNAC_ROUTER == (radvert->nd_ra_flags_reserved & ND_RA_FLAG_SNAC_ROUTER)))
+		printf("\tAdvSNACRouterFlag %s;\n", (radvert->nd_ra_flags_reserved & ND_RA_FLAG_SNAC_ROUTER) ? "on" : "off");
+
 	/* Route Preferences and more specific routes */
 	/* XXX two middlemost bits from 8 bit field */
 	if (!edefs || (((radvert->nd_ra_flags_reserved & 0x18) >> 3) & 0xff) != DFLT_AdvDefaultPreference) {

--- a/scanner.l
+++ b/scanner.l
@@ -87,6 +87,7 @@ UnicastOnly		{ return T_UnicastOnly; }
 UnrestrictedUnicast	{ return T_UnrestrictedUnicast; }
 AdvRASolicitedUnicast	{ return T_AdvRASolicitedUnicast; }
 AdvCaptivePortalAPI	{ return T_AdvCaptivePortalAPI; }
+AdvSNACRouterFlag	{ return T_AdvSNACRouterFlag; }
 
 Base6Interface		{ return T_Base6Interface; }
 Base6to4Interface	{ return T_Base6to4Interface; }

--- a/send.c
+++ b/send.c
@@ -221,6 +221,7 @@ static void add_ra_header(struct safe_buffer *sb, struct ra_header_info const *r
 	radvert.nd_ra_flags_reserved |= (ra_header_info->AdvOtherConfigFlag) ? ND_RA_FLAG_OTHER : 0;
 	/* Mobile IPv6 ext */
 	radvert.nd_ra_flags_reserved |= (ra_header_info->AdvHomeAgentFlag) ? ND_RA_FLAG_HOME_AGENT : 0;
+	radvert.nd_ra_flags_reserved |= (ra_header_info->AdvSNACRouterFlag) ? ND_RA_FLAG_SNAC_ROUTER : 0;
 
 	radvert.nd_ra_router_lifetime = cease_adv ? 0 : htons(ra_header_info->AdvDefaultLifetime);
 	radvert.nd_ra_flags_reserved |= (ra_header_info->AdvDefaultPreference << ND_OPT_RI_PRF_SHIFT) & ND_OPT_RI_PRF_MASK;


### PR DESCRIPTION
Adds a new option: AdvSNACRouterFlag. When enabled, this sets RA option bit 6, a formerly reserved bit, that is seems to be now [allocated to "SNAC router"](https://www.iana.org/assignments/icmpv6-parameters/icmpv6-parameters.xhtml#icmpv6-parameters-11).

The reason for this addition is that I noticed Apple's HomeKit devices setting this flag to 1 when advertising themselves as a Thread border router. I have multiple VLANs, and I wanted to use radvd to re-advertise the route with identical options (but different router address).

In 2019 this same bit [has been proposed to stand for IPv6 only](https://datatracker.ietf.org/doc/html/draft-ietf-6man-ipv6only-flag-05), but that does not seem to have been adopted as standard. However, [tcpdump](https://github.com/the-tcpdump-group/tcpdump/blob/master/print-icmp6.c#L216) still decodes the bit as "ipv6 only". These two uses aren't necessarily contradictory, since the Stub Network advertised as such is indeed IPv6 only.