### PR TITLE
Add DHCPv6-PD Preferred flag support (RFC 9762)

### DIFF
--- a/defaults.h
+++ b/defaults.h
@@ -61,6 +61,7 @@
 #define DFLT_AdvOnLinkFlag 1
 #define DFLT_AdvPreferredLifetime 14400 /* seconds */
 #define DFLT_AdvAutonomousFlag 1
+#define DFLT_AdvDHCPv6PDPreferredFlag 0
 #define DFLT_DeprecatePrefixFlag 0
 #define DFLT_DecrementLifetimesFlag 0
 
@@ -234,6 +235,9 @@ struct nd_opt_dnssl_info_local {
 #endif
 #ifndef ND_OPT_PI_FLAG_RADDR
 #define ND_OPT_PI_FLAG_RADDR 0x20
+#endif
+#ifndef ND_OPT_PI_FLAG_DHCPv6_PD_PREF
+#define ND_OPT_PI_FLAG_DHCPv6_PD_PREF 0x10
 #endif
 #ifndef ND_OPT_RDNSSI_FLAG_S
 #if BYTE_ORDER == BIG_ENDIAN

--- a/gram.y
+++ b/gram.y
@@ -87,6 +87,7 @@ int yylex_destroy (void);
 
 %token		T_AdvOnLink
 %token		T_AdvAutonomous
+%token		T_AdvDHCPv6PDPreferred
 %token		T_AdvValidLifetime
 %token		T_AdvPreferredLifetime
 %token		T_DeprecatePrefix
@@ -710,6 +711,12 @@ prefixparms	: T_AdvOnLink SWITCH ';'
 		{
 			if (prefix) {
 				prefix->AdvRouterAddr = $2;
+			}
+		}
+		| T_AdvDHCPv6PDPreferred SWITCH ';'
+		{
+			if (prefix) {
+				prefix->AdvDHCPv6PDPreferredFlag = $2;
 			}
 		}
 		| T_AdvValidLifetime number_or_infinity ';'

--- a/interface.c
+++ b/interface.c
@@ -124,6 +124,7 @@ void prefix_init_defaults(struct AdvPrefix *prefix)
 	prefix->AdvOnLinkFlag = DFLT_AdvOnLinkFlag;
 	prefix->AdvAutonomousFlag = DFLT_AdvAutonomousFlag;
 	prefix->AdvRouterAddr = DFLT_AdvRouterAddr;
+	prefix->AdvDHCPv6PDPreferredFlag = DFLT_AdvDHCPv6PDPreferredFlag;
 	prefix->AdvValidLifetime = DFLT_AdvValidLifetime;
 	prefix->AdvPreferredLifetime = DFLT_AdvPreferredLifetime;
 	prefix->DeprecatePrefixFlag = DFLT_DeprecatePrefixFlag;

--- a/radvd.conf.5.man
+++ b/radvd.conf.5.man
@@ -496,6 +496,17 @@ MaxRtrAdvInterval.
 Default: off
 
 .TP
+.BR AdvDHCPv6PDPreferred " " on | off
+
+When set, indicates that the network prefers that clients use
+prefix delegation instead of acquiring individual addresses
+via SLAAC or DHCPv6 aaddress assignment.
+
+See RFC 9762, "Using Router Advertisements to Signal the Availability of DHCPv6 Prefix Delegation to Clients"
+
+Default: off
+
+.TP
 .BR "AdvValidLifetime " seconds "" | infinity
 
 The length of time in seconds (relative to the time the packet is

--- a/radvd.h
+++ b/radvd.h
@@ -152,6 +152,7 @@ struct AdvPrefix {
 
 	int AdvOnLinkFlag;
 	int AdvAutonomousFlag;
+	int AdvDHCPv6PDPreferredFlag;
 	uint32_t AdvValidLifetime;
 	uint32_t AdvPreferredLifetime;
 	int DeprecatePrefixFlag;

--- a/radvdump.c
+++ b/radvdump.c
@@ -364,6 +364,12 @@ static void print_ff(unsigned char *msg, int len, struct sockaddr_in6 *addr, int
 				(ND_OPT_PI_FLAG_RADDR == (pinfo->nd_opt_pi_flags_reserved & ND_OPT_PI_FLAG_RADDR)))
 				printf("\t\tAdvRouterAddr %s;\n",
 				       (pinfo->nd_opt_pi_flags_reserved & ND_OPT_PI_FLAG_RADDR) ? "on" : "off");
+			
+			if (!edefs ||
+			    DFLT_AdvDHCPv6PDPreferredFlag !=
+				(ND_OPT_PI_FLAG_DHCPv6_PD_PREF == (pinfo->nd_opt_pi_flags_reserved & ND_OPT_PI_FLAG_DHCPv6_PD_PREF)))
+				printf("\t\tAdvDHCPv6PDPreferred %s;\n",
+				       (pinfo->nd_opt_pi_flags_reserved & ND_OPT_PI_FLAG_DHCPv6_PD_PREF) ? "on" : "off");
 
 			printf("\t}; # End of prefix definition\n\n");
 			break;

--- a/scanner.l
+++ b/scanner.l
@@ -74,6 +74,7 @@ RemoveAdvOnExit		{ return T_RemoveAdvOnExit; }
 
 AdvOnLink		{ return T_AdvOnLink; }
 AdvAutonomous		{ return T_AdvAutonomous; }
+AdvDHCPv6PDPreferred	{ return T_AdvDHCPv6PDPreferred; }
 AdvValidLifetime	{ return T_AdvValidLifetime; }
 AdvPreferredLifetime	{ return T_AdvPreferredLifetime; }
 DeprecatePrefix		{ return T_DeprecatePrefix; }

--- a/send.c
+++ b/send.c
@@ -245,6 +245,7 @@ static void add_ra_option_prefix(struct safe_buffer *sb, struct AdvPrefix const 
 	pinfo.nd_opt_pi_flags_reserved |= (prefix->AdvAutonomousFlag) ? ND_OPT_PI_FLAG_AUTO : 0;
 	/* Mobile IPv6 ext */
 	pinfo.nd_opt_pi_flags_reserved |= (prefix->AdvRouterAddr) ? ND_OPT_PI_FLAG_RADDR : 0;
+	pinfo.nd_opt_pi_flags_reserved |= (prefix->AdvDHCPv6PDPreferredFlag) ? ND_OPT_PI_FLAG_DHCPv6_PD_PREF : 0;
 
 	if (cease_adv && prefix->DeprecatePrefixFlag) {
 		/* RFC4862, 5.5.3, step e) */


### PR DESCRIPTION
This change adds support for advertising the DHCPv6-PD Preferred (P) flag in Prefix Information Options, as specified in RFC 9762.
The P flag allows routers to indicate to clients that DHCPv6-PD is available on the network.

https://www.rfc-editor.org/rfc/rfc9762.html

Wireshark already supports parsing and displaying this flag as “DHCPv6-PD Preferred Flag (P)” in Prefix Information Options.

<img width="836" height="182" alt="Screenshot 2025-11-07 at 19 58 19" src="https://github.com/user-attachments/assets/9f46ad54-da72-489c-906b-77a5cf4b8500" />

Note that, since glibc does not seem to define `ND_OPT_PI_FLAG_*` constants for this flag, the current naming (`ND_OPT_PI_FLAG_DHCPv6_PD_PREF`) may not be optimal.

I also saw the Android Developers Blog post “[Simplifying advanced networking with DHCPv6 Prefix Delegation](https://android-developers.googleblog.com/2025/09/simplifying-advanced-networking-with.html),” which relates to this topic.