### PR TITLE
radvdump: add '-u username' to help output

### DIFF
--- a/radvdump.c
+++ b/radvdump.c
@@ -23,7 +23,7 @@
 #define bswap64(y) (y)
 #endif
 
-static char usage_str[] = "[-vhfe] [-d level]";
+static char usage_str[] = "[-vhfe] [-d level] [-u username]";
 
 #ifdef HAVE_GETOPT_LONG
 struct option prog_opt[] = {


### PR DESCRIPTION
The manpage reflects the extra argument introduced in
	068bde1 ("feat: harden radvdump (CVE-2026-48715)")
but it was forgotten in the help output.