### PR TITLE
RFC 9463 (Discovery of Network-designated Resolvers) support

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -200,6 +200,9 @@ EXTRA_DIST = \
 	test/test_dnssl4.conf \
 	test/test_dnssl5.conf \
 	test/test_dnssl6.conf \
+	test/test_dnr_adn_only.conf \
+	test/test_dnr_addrs.conf \
+	test/test_dnr_svcparams.conf \
 	test/test_rdnss.conf \
 	test/test_rdnss_long.conf \
 	test/util.c \

--- a/defaults.h
+++ b/defaults.h
@@ -99,6 +99,14 @@
 #define DFLT_AdvDNSSLLifetime(iface) (3 * (iface)->MaxRtrAdvInterval)
 #define DFLT_FlushDNSSLFlag 1
 
+/* DNR
+ * https://www.rfc-editor.org/rfc/rfc9463#section-6.1
+ * "The value of Lifetime SHOULD by default be at least 3 * MaxRtrAdvInterval"
+ */
+#define DFLT_AdvDNRLifetime(iface) (3 * (iface)->MaxRtrAdvInterval)
+#define DFLT_AdvDNRPriority 1
+#define DFLT_FlushDNRFlag 1
+
 /* Protocol (RFC4861) constants: */
 
 /* Router constants: */
@@ -225,6 +233,22 @@ struct nd_opt_dnssl_info_local {
 	uint16_t nd_opt_dnssli_reserved;
 	uint32_t nd_opt_dnssli_lifetime;
 	unsigned char nd_opt_dnssli_suffixes[];
+};
+
+#undef ND_OPT_DNR_INFORMATION
+#define ND_OPT_DNR_INFORMATION 144
+
+/* SvcParamKeys carried in the DNR option */
+#define DNR_SVCPARAM_KEY_ALPN    1 /* RFC 9460 section 7.1 */
+#define DNR_SVCPARAM_KEY_PORT    3 /* RFC 9460 section 7.2 */
+#define DNR_SVCPARAM_KEY_DOHPATH 7 /* RFC 9461 section 5.1 */
+
+struct nd_opt_dnr_info_local {
+	uint8_t nd_opt_dnri_type;
+	uint8_t nd_opt_dnri_len;
+	uint16_t nd_opt_dnri_priority;
+	uint32_t nd_opt_dnri_lifetime;
+	uint8_t nd_opt_dnri_data[];
 };
 
 /* Flags */

--- a/gram.y
+++ b/gram.y
@@ -52,6 +52,7 @@ int yylex_destroy (void);
 %token		T_ROUTE
 %token		T_RDNSS
 %token		T_DNSSL
+%token		T_DNR
 %token		T_CLIENTS
 %token		T_LOWPANCO
 %token		T_ABRO
@@ -120,6 +121,14 @@ int yylex_destroy (void);
 %token		T_AdvDNSSLLifetime
 %token		T_FlushDNSSL
 
+%token		T_AdvDNRPriority
+%token		T_AdvDNRLifetime
+%token		T_AdvDNRAddr
+%token		T_AdvDNRSvcAlpn
+%token		T_AdvDNRSvcPort
+%token		T_AdvDNRSvcDohpath
+%token		T_FlushDNR
+
 %token		T_AdvMobRtrSupportFlag
 
 %token		T_AdvContextLength
@@ -140,6 +149,7 @@ int yylex_destroy (void);
 %type	<rinfo>	routedef
 %type	<rdnssinfo> rdnssdef
 %type	<dnsslinfo> dnssldef
+%type	<dnrinfo> dnrdef
 %type   <lowpancoinfo> lowpancodef
 %type   <abroinfo> abrodef
 %type   <num>	number_or_infinity
@@ -157,6 +167,7 @@ int yylex_destroy (void);
 	struct AdvRoute		*rinfo;
 	struct AdvRDNSS		*rdnssinfo;
 	struct AdvDNSSL		*dnsslinfo;
+	struct AdvDNR           *dnrinfo;
 	struct Clients		*ainfo;
 	struct AdvLowpanCo	*lowpancoinfo;
 	struct AdvAbro		*abroinfo;
@@ -174,6 +185,7 @@ static struct AdvPrefix *prefix;
 static struct AdvRoute *route;
 static struct AdvRDNSS *rdnss;
 static struct AdvDNSSL *dnssl;
+static struct AdvDNR *dnr;
 static struct AdvLowpanCo *lowpanco;
 static struct AdvAbro  *abro;
 static struct NAT64Prefix *nat64prefix;
@@ -245,6 +257,7 @@ ifaceparam 	: ifaceval
 		| routedef 	{ ADD_TO_LL(struct AdvRoute, AdvRouteList, $1); }
 		| rdnssdef 	{ ADD_TO_LL(struct AdvRDNSS, AdvRDNSSList, $1); }
 		| dnssldef 	{ ADD_TO_LL(struct AdvDNSSL, AdvDNSSLList, $1); }
+		| dnrdef 	{ ADD_TO_LL(struct AdvDNR, AdvDNRList, $1); }
 		| lowpancodef   { ADD_TO_LL(struct AdvLowpanCo, AdvLowpanCoList, $1); }
 		| abrodef       { ADD_TO_LL(struct AdvAbro, AdvAbroList, $1); }
 		| rasrcaddresslist { ADD_TO_LL(struct AdvRASrcAddress, AdvRASrcAddressList, $1); }
@@ -988,6 +1001,265 @@ dnsslparms	: T_AdvDNSSLLifetime number_or_infinity ';'
 		}
 		;
 
+dnrdef		: dnrhead '{' optional_dnrplist '}' ';'
+		{
+			/* RFC 9463 §6.1: Addr Length, ipv6-address(es), and SvcParams
+			 * fields are not present in ADN-only mode. */
+			if (dnr->AdvDNRNumber == 0 &&
+			    (dnr->AdvDNRSvcAlpn || dnr->AdvDNRSvcPort || dnr->AdvDNRSvcDohpath)) {
+				flog(LOG_ERR, "DNR entry for '%s' at %s, line %d has Svc options "
+					"but no AdvDNRAddr; Svc options are disallowed in ADN-only mode",
+					dnr->AdvDNRADN, filename, num_lines);
+				ABORT;
+			}
+
+			$$ = dnr;
+			dnr = NULL;
+		}
+		;
+
+dnrhead		: T_DNR STRING
+	 	{
+			const char *source = $2;
+			size_t len = strlen(source);
+			int label_len = 0;
+
+			dnr = malloc(sizeof(struct AdvDNR));
+
+			if (dnr == NULL) {
+				flog(LOG_CRIT, "malloc failed: %s", strerror(errno));
+				ABORT;
+			}
+
+			dnr_init_defaults(dnr, iface);
+
+			/* Strip surrounding quotes if the ADN was given as a quoted string */
+			if ((len > 0) && (source[0] == '"')) {
+				source++;
+				len--;
+			}
+			if ((len > 0) && (source[len-1] == '"')) {
+				len--;
+			}
+
+			if (len <= 0) {
+				flog(LOG_ERR, "DNR ADN is empty "
+					"at %s, line %d", filename, num_lines);
+				ABORT;
+			}
+			if (source[len-1] == '.') {
+				flog(LOG_ERR, "DNR ADN has a trailing dot "
+					"at %s, line %d", filename, num_lines);
+				ABORT;
+			}
+
+			/* Domain name validation from RFC 1035, Section 3.1 */
+			if (len > 255) {
+				flog(LOG_ERR, "DNR ADN total length is greater than 255 bytes "
+					"at %s, line %d", filename, num_lines);
+				ABORT;
+			}
+
+			for (int i = 0; i < (int)len; i++) {
+				if (source[i] == '.') {
+					if (label_len == 0) {
+						flog(LOG_ERR, "DNR ADN has an empty label "
+							"at %s, line %d", filename, num_lines);
+						ABORT;
+					}
+					label_len = 0;
+				} else {
+					if (label_len == 63) {
+						flog(LOG_ERR, "DNR ADN has a label with > 63 bytes "
+							"at %s, line %d", filename, num_lines);
+						ABORT;
+					}
+					label_len++;
+				}
+			}
+
+			dnr->AdvDNRADN = strndup(source, len);
+
+			if (dnr->AdvDNRADN == NULL) {
+				flog(LOG_CRIT, "malloc failed: %s", strerror(errno));
+				ABORT;
+			}
+		}
+		;
+
+optional_dnrplist: /* empty */
+		| dnrplist
+		;
+
+dnrplist	: dnrplist dnrparms
+	 	| dnrparms
+		;
+
+dnrparms	: T_AdvDNRPriority NUMBER ';'
+	 	{
+			if ($2 > UINT16_MAX) {
+				flog(LOG_ERR, "AdvDNRPriority must be a 16-bit number, "
+					"got %u at %s, line %d", $2, filename, num_lines);
+				ABORT;
+			}
+			dnr->AdvDNRPriority = $2;
+		}
+		| T_AdvDNRLifetime number_or_infinity ';'
+		{
+			dnr->AdvDNRLifetime = $2;
+		}
+		| T_FlushDNR SWITCH ';'
+		{
+			dnr->FlushDNRFlag = $2;
+		}
+		| T_AdvDNRAddr IPV6ADDR ';'
+		{
+			dnr->AdvDNRNumber++;
+			if (dnr->AdvDNRNumber > (int)(UINT16_MAX / sizeof(struct in6_addr))) {
+				flog(LOG_CRIT, "Too many DNR addresses specified - "
+					"upper limit is %"PRIu16" based on Addr Length field being uint16, "
+					"RFC9463, section 6.1", (uint16_t)(UINT16_MAX / sizeof(struct in6_addr)));
+				ABORT;
+			}
+			dnr->AdvDNRAddrs =
+				realloc(dnr->AdvDNRAddrs,
+					dnr->AdvDNRNumber * sizeof(struct in6_addr));
+			if (dnr->AdvDNRAddrs == NULL) {
+				flog(LOG_CRIT, "realloc failed: %s", strerror(errno));
+				ABORT;
+			}
+			/* RFC 9463 §6.2: hosts MUST silently discard multicast and loopback addresses */
+			if (IN6_IS_ADDR_MULTICAST($2) || IN6_IS_ADDR_LOOPBACK($2)) {
+				flog(LOG_WARNING, "DNR address at %s, line %d is multicast or loopback; "
+					"hosts will discard it per RFC 9463 §6.2",
+					filename, num_lines);
+			}
+			memcpy(&dnr->AdvDNRAddrs[dnr->AdvDNRNumber - 1], $2, sizeof(struct in6_addr));
+		}
+		| T_AdvDNRSvcPort NUMBER ';'
+		{
+			if ($2 > UINT16_MAX) {
+				flog(LOG_ERR, "AdvDNRSvcPort must be a 16-bit number, "
+					"got %u at %s, line %d", $2, filename, num_lines);
+				ABORT;
+			}
+			dnr->AdvDNRSvcPort = $2;
+		}
+		| T_AdvDNRSvcAlpn STRING ';'
+		{
+			const char *source = $2;
+			size_t len = strlen(source);
+			int comma = 0;
+
+			if (dnr->AdvDNRSvcAlpn != NULL) {
+				flog(LOG_WARNING, "warning: AdvDNRSvcAlpn specified twice for DNR "
+					"at %s, line %d", filename, num_lines);
+				free(dnr->AdvDNRSvcAlpn);
+				dnr->AdvDNRSvcAlpn = NULL;
+			}
+
+			if ((len > 0) && (source[0] == '"')) {
+				source++;
+				len--;
+			}
+			if ((len > 0) && (source[len-1] == '"')) {
+				len--;
+			}
+
+			if (len <= 0) {
+				flog(LOG_ERR, "AdvDNRSvcAlpn empty ALPN specified for DNR "
+					"at %s, line %d", filename, num_lines);
+				ABORT;
+			}
+			if (source[0] == ',') {
+				flog(LOG_ERR, "AdvDNRSvcAlpn has a leading comma "
+					"at %s, line %d", filename, num_lines);
+				ABORT;
+			}
+			if (source[len-1] == ',') {
+				flog(LOG_ERR, "AdvDNRSvcAlpn has a trailing comma "
+					"at %s, line %d", filename, num_lines);
+				ABORT;
+			}
+			int token_len = 0;
+			for (int i = 0; i < (int)len; i++) {
+				if (source[i] == '\\') {
+					flog(LOG_ERR, "AdvDNRSvcAlpn contains '\\' "
+						"at %s, line %d", filename, num_lines);
+					ABORT;
+				}
+				if (source[i] == ',') {
+					if (comma) {
+						flog(LOG_ERR, "AdvDNRSvcAlpn has an empty item (contains \",,\") "
+							"at %s, line %d", filename, num_lines);
+						ABORT;
+					}
+					comma = 1;
+					token_len = 0;
+				} else {
+					comma = 0;
+					/* RFC 9460 §7.1: each ALPN identifier is wire-encoded
+					 * with a 1-byte length prefix, so it must be <= 255 bytes */
+					if (++token_len > 255) {
+						flog(LOG_ERR, "AdvDNRSvcAlpn item exceeds 255 bytes "
+							"at %s, line %d", filename, num_lines);
+						ABORT;
+					}
+				}
+			}
+
+			dnr->AdvDNRSvcAlpn = strndup(source, len);
+
+			if (dnr->AdvDNRSvcAlpn == NULL) {
+				flog(LOG_CRIT, "malloc failed: %s", strerror(errno));
+				ABORT;
+			}
+		}
+		| T_AdvDNRSvcDohpath STRING ';'
+		{
+			const char *source = $2;
+			size_t len = strlen(source);
+
+			if (dnr->AdvDNRSvcDohpath) {
+				flog(LOG_WARNING, "warning: AdvDNRSvcDohpath specified twice for DNR "
+					"at %s, line %d", filename, num_lines);
+				free(dnr->AdvDNRSvcDohpath);
+				dnr->AdvDNRSvcDohpath = NULL;
+			}
+
+			if ((len > 0) && (source[0] == '"')) {
+				source++;
+				len--;
+			}
+			if ((len > 0) && (source[len-1] == '"')) {
+				len--;
+			}
+			if (len <= 0) {
+				flog(LOG_ERR, "AdvDNRSvcDohpath empty URL specified for DNR "
+					"at %s, line %d", filename, num_lines);
+				ABORT;
+			}
+
+			if (strstr(source, "dns}") == NULL) {
+				flog(LOG_WARNING,
+					"warning: AdvDNRSvcDohpath specified without 'dns' "
+					"template variable as required by RFC 9461, Section 5");
+			}
+
+			if (source[0] != '/') {
+				flog(LOG_WARNING, "warning: AdvDNRSvcDohpath is not a URI Template "
+					"in relative form as required by RFC 9461, Section 5");
+			}
+
+			dnr->AdvDNRSvcDohpath = strndup(source, len);
+
+			if (dnr->AdvDNRSvcDohpath == NULL) {
+				flog(LOG_CRIT, "malloc failed: %s", strerror(errno));
+				ABORT;
+			}
+		}
+		;
+
 lowpancodef 	: lowpancohead  '{' optional_lowpancoplist '}' ';'
 		{
 			$$ = lowpanco;
@@ -1141,6 +1413,15 @@ static void cleanup(void)
 		free(dnssl->AdvDNSSLSuffixes);
 		free(dnssl);
 		dnssl = 0;
+	}
+
+	if (dnr) {
+		free(dnr->AdvDNRAddrs);
+		free(dnr->AdvDNRADN);
+		free(dnr->AdvDNRSvcAlpn);
+		free(dnr->AdvDNRSvcDohpath);
+		free(dnr);
+		dnr = NULL;
 	}
 
 	if (lowpanco) {

--- a/interface.c
+++ b/interface.c
@@ -169,6 +169,15 @@ void dnssl_init_defaults(struct AdvDNSSL *dnssl, struct Interface *iface)
 	dnssl->FlushDNSSLFlag = DFLT_FlushDNSSLFlag;
 }
 
+void dnr_init_defaults(struct AdvDNR *dnr, struct Interface *iface)
+{
+	memset(dnr, 0, sizeof(struct AdvDNR));
+
+	dnr->AdvDNRPriority = DFLT_AdvDNRPriority;
+	dnr->AdvDNRLifetime = DFLT_AdvDNRLifetime(iface);
+	dnr->FlushDNRFlag = DFLT_FlushDNRFlag;
+}
+
 int check_iface(struct Interface *iface)
 {
 	int res = 0;
@@ -436,6 +445,19 @@ static void free_iface_list(struct Interface *iface)
 			free(dnssl);
 
 			dnssl = next_dnssl;
+		}
+
+		struct AdvDNR *dnr = iface->AdvDNRList;
+		while (dnr) {
+			struct AdvDNR *next_dnr = dnr->next;
+
+			free(dnr->AdvDNRAddrs);
+			free(dnr->AdvDNRADN);
+			free(dnr->AdvDNRSvcAlpn);
+			free(dnr->AdvDNRSvcDohpath);
+			free(dnr);
+
+			dnr = next_dnr;
 		}
 
 		struct AutogenIgnorePrefix *ignore_prefixes = iface->IgnorePrefixList;

--- a/process.c
+++ b/process.c
@@ -391,6 +391,7 @@ static void process_ra(struct Interface *iface, unsigned char *msg, int len, str
 			}
 			break;
 		}
+		case ND_OPT_DNR_INFORMATION:
 		case ND_OPT_PREF64:
 		case ND_OPT_CAPTIVE_PORTAL:
 			/* not checked */

--- a/radvd.conf.5.man
+++ b/radvd.conf.5.man
@@ -31,6 +31,7 @@ The file contains one or more interface definitions of the form:
 	list of route definitions
 	list of RDNSS definitions
 	list of DNSSL definitions
+	list of DNR definitions
 	list of ABRO definitions
 	list of NAT64 pref64 definitions
 	list of auto-ignore prefixes
@@ -135,6 +136,16 @@ virtual/failover MAC.
         list of IPv6 addresses
 .B };
 .fi
+
+DNR (Discovery of Network-designated Resolvers) definitions are of the form:
+
+.nf
+.BR "DNR " "authentication-domain-name " {
+	list of DNR specific options
+.B };
+.fi
+
+This option can be specified multiple times.
 
 ABRO (Authoritative Border Router Option) definitions are of the form:
 
@@ -661,6 +672,53 @@ Default: 3*MaxRtrAdvInterval
 .BR FlushDNSSL " " on | off
 
 Upon shutdown, announce the DNSSL entries with a zero second lifetime. This should cause the DNSSL entries to be immediately removed from the end-nodes' DNS search list.
+
+Default: on
+
+.SH DNR SPECIFIC OPTIONS
+
+.TP
+.BR "AdvDNRAddr " IPv6-address;
+Advertise the resolver's IPv6 address.
+This option can be specified multiple times.
+If this option is not specified, the DNR advertisement will be considered
+to be using ADN-Only mode, and Svc options will be disallowed.
+
+.TP
+.BR "AdvDNRPriority " number;
+The priority of the encrypted DNS instance relative to others.
+
+Default: 1
+
+.TP
+.BR "AdvDNRSvcPort " number;
+Indicates the target port number for encrypted DNS.
+If not specified, clients will use the default port for the protocol.
+
+.TP
+.BR "AdvDNRSvcAlpn " string;
+The supported protocols, formatted as an ALPN string.
+For example, a DNS-over-HTTPS resolver may specify "http/1.1,h2,h3"
+for HTTP/1.1, HTTP/2, and HTTP/3 (QUIC) support,
+while a DNS-over-TLS resolver may specify "dot" for DNS-over-TLS.
+This option should be specified.
+
+.TP
+.BR "AdvDNRSvcDohpath " string;
+The DNS-over-HTTPS URI Template that clients should use for the resolver.
+
+.TP
+.BR "AdvDNRLifetime " seconds | infinity;
+The maximum duration how long the DNR entries are used for name resolution.
+A value of 0 means the nameserver should no longer be used.
+
+Default: 3*MaxRtrAdvInterval
+
+.TP
+.BR FlushDNR " " on | off
+
+Upon shutdown, announce the DNR entries with a zero second lifetime.
+This should cause the DNR entries to be immediately removed from the end-nodes' nameserver list.
 
 Default: on
 

--- a/radvd.h
+++ b/radvd.h
@@ -103,6 +103,7 @@ struct Interface {
 	struct AdvRoute *AdvRouteList;
 	struct AdvRDNSS *AdvRDNSSList;
 	struct AdvDNSSL *AdvDNSSLList;
+	struct AdvDNR *AdvDNRList;
 
 	struct NAT64Prefix *NAT64PrefixList;
 
@@ -222,6 +223,20 @@ struct AdvDNSSL {
 	struct AdvDNSSL *next;
 };
 
+struct AdvDNR {
+	uint16_t AdvDNRPriority;
+	uint16_t AdvDNRSvcPort;
+	uint32_t AdvDNRLifetime;
+	int FlushDNRFlag;
+	int AdvDNRNumber;
+	char *AdvDNRADN;
+	struct in6_addr *AdvDNRAddrs;
+	char *AdvDNRSvcAlpn;
+	char *AdvDNRSvcDohpath;
+
+	struct AdvDNR *next;
+};
+
 /* Options for 6lopan configuration */
 
 struct AdvLowpanCo {
@@ -337,6 +352,7 @@ int cleanup_iface(int sock, struct Interface *iface);
 struct Interface *find_iface_by_index(struct Interface *iface, int index);
 struct Interface *find_iface_by_name(struct Interface *iface, const char *name);
 struct Interface *find_iface_by_time(struct Interface *iface_list);
+void dnr_init_defaults(struct AdvDNR *, struct Interface *);
 void dnssl_init_defaults(struct AdvDNSSL *, struct Interface *);
 void for_each_iface(struct Interface *ifaces, void (*foo)(struct Interface *iface, void *), void *data);
 void free_ifaces(struct Interface *ifaces);

--- a/radvdump.c
+++ b/radvdump.c
@@ -166,6 +166,45 @@ int main(int argc, char *argv[])
 	exit(0);
 }
 
+/* Read big-endian fields byte-wise, independent of buffer alignment. */
+static uint16_t get_be16(uint8_t const *p)
+{
+	return (uint16_t)((p[0] << 8) | p[1]);
+}
+
+static uint32_t get_be32(uint8_t const *p)
+{
+	return ((uint32_t)p[0] << 24) | ((uint32_t)p[1] << 16) | ((uint32_t)p[2] << 8) | p[3];
+}
+
+/*
+ * Join a run of 1-byte-length-prefixed items into `sep`-separated text.
+ * Used for both DNS labels (sep '.') and ALPN tokens (sep ','). Stops at a
+ * zero-length item (the DNS root label) or the end of the buffer. Returns 0
+ * if an item runs past `len` or overflows `out`.
+ */
+static int join_prefixed(uint8_t const *buf, int len, char sep, char *out, size_t outsz)
+{
+	out[0] = '\0';
+	for (int i = 0; i < len;) {
+		int n = buf[i++];
+
+		if (n == 0)
+			break;
+		if (i + n > len || strlen(out) + n + 2 > outsz)
+			return 0;
+
+		if (out[0] != '\0') {
+			size_t end = strlen(out);
+			out[end] = sep;
+			out[end + 1] = '\0';
+		}
+		strncat(out, (char const *)&buf[i], n);
+		i += n;
+	}
+	return 1;
+}
+
 static void print_ff(unsigned char *msg, int len, struct sockaddr_in6 *addr, int hoplimit, unsigned int if_index, int edefs)
 {
 	/* XXX: hoplimit not being used for anything here.. */
@@ -314,6 +353,8 @@ static void print_ff(unsigned char *msg, int len, struct sockaddr_in6 *addr, int
 		case ND_OPT_RDNSS_INFORMATION:
 			break;
 		case ND_OPT_DNSSL_INFORMATION:
+			break;
+		case ND_OPT_DNR_INFORMATION:
 			break;
 		case ND_OPT_PREF64:
 			break;
@@ -526,6 +567,90 @@ static void print_ff(unsigned char *msg, int len, struct sockaddr_in6 *addr, int
 				printf("\t\tAdvDNSSLLifetime %u;\n", ntohl(dnssl_info->nd_opt_dnssli_lifetime));
 
 			printf("\t}; # End of DNSSL definition\n\n");
+			break;
+		}
+		case ND_OPT_DNR_INFORMATION: {
+			char adn[256];
+
+			/* RFC 9463 §6.1: 8-byte header, 2-byte ADN Length, then the ADN */
+			if (optlen < 10 || 10 + (int)get_be16(opt_str + 8) > optlen) {
+				flog(LOG_ERR, "Invalid DNR option from %s", addr_str);
+				printf("# Invalid DNR option ");
+				break;
+			}
+
+			int adn_len = get_be16(opt_str + 8);
+			if (!join_prefixed(opt_str + 10, adn_len, '.', adn, sizeof(adn)) || adn[0] == '\0') {
+				flog(LOG_ERR, "Invalid DNR ADN from %s", addr_str);
+				printf("# Invalid DNR ADN ");
+				break;
+			}
+
+			uint32_t lifetime = get_be32(opt_str + 4);
+
+			printf("\n\tDNR %s\n\t{\n", adn);
+			printf("\t\tAdvDNRPriority %hu;\n", get_be16(opt_str + 2));
+			/* as AdvDNRLifetime may depend on MaxRtrAdvInterval, it could change */
+			if (lifetime == 0xffffffff)
+				printf("\t\tAdvDNRLifetime infinity; # (0xffffffff)\n");
+			else
+				printf("\t\tAdvDNRLifetime %u;\n", lifetime);
+
+			int off = 10 + adn_len;
+
+			/* Addr Length + addresses. Absent in ADN-only mode, where the
+			 * trailing zero padding reads as a zero Addr Length below. */
+			if (off + 2 <= optlen) {
+				int addr_len = get_be16(opt_str + off);
+				off += 2;
+				if (addr_len % (int)sizeof(struct in6_addr) == 0 && off + addr_len <= optlen) {
+					struct in6_addr addr;
+					for (int a = 0; a < addr_len; a += (int)sizeof(struct in6_addr)) {
+						memcpy(&addr, opt_str + off + a, sizeof(addr));
+						addrtostr(&addr, prefix_str, sizeof(prefix_str));
+						printf("\t\tAdvDNRAddr %s;\n", prefix_str);
+					}
+				}
+				off += addr_len;
+			}
+
+			/* SvcParams: a run of key(2) len(2) value entries (RFC 9460 §2.2) */
+			if (off + 2 <= optlen) {
+				int end = off + 2 + get_be16(opt_str + off);
+				if (end > optlen)
+					end = optlen;
+				off += 2;
+
+				while (off + 4 <= end) {
+					int key = get_be16(opt_str + off);
+					int vlen = get_be16(opt_str + off + 2);
+					uint8_t const *val = opt_str + off + 4;
+					off += 4 + vlen;
+					if (off > end)
+						break;
+
+					switch (key) {
+					case DNR_SVCPARAM_KEY_ALPN: { /* RFC 9460 §7.1 */
+						char alpn[256];
+						if (join_prefixed(val, vlen, ',', alpn, sizeof(alpn)) && alpn[0])
+							printf("\t\tAdvDNRSvcAlpn \"%s\";\n", alpn);
+						break;
+					}
+					case DNR_SVCPARAM_KEY_PORT: /* RFC 9460 §7.2 */
+						if (vlen == 2)
+							printf("\t\tAdvDNRSvcPort %hu;\n", get_be16(val));
+						break;
+					case DNR_SVCPARAM_KEY_DOHPATH: /* RFC 9461 §5.1 */
+						printf("\t\tAdvDNRSvcDohpath \"%.*s\";\n", vlen, (const char *)val);
+						break;
+					default:
+						printf("\t\t# Unsupported SvcParamKey %d (%d bytes)\n", key, vlen);
+						break;
+					}
+				}
+			}
+
+			printf("\t}; # End of DNR definition\n\n");
 			break;
 		}
 		case ND_OPT_PREF64: {

--- a/scanner.l
+++ b/scanner.l
@@ -48,6 +48,7 @@ prefix			{ return T_PREFIX; }
 route			{ return T_ROUTE; }
 RDNSS			{ return T_RDNSS; }
 DNSSL			{ return T_DNSSL; }
+DNR			{ return T_DNR; }
 clients			{ return T_CLIENTS; }
 lowpanco		{ return T_LOWPANCO; }
 abro			{ return T_ABRO; }
@@ -106,6 +107,14 @@ FlushRDNSS		{ return T_FlushRDNSS; }
 
 AdvDNSSLLifetime	{ return T_AdvDNSSLLifetime; }
 FlushDNSSL		{ return T_FlushDNSSL; }
+
+AdvDNRPriority		{ return T_AdvDNRPriority; }
+AdvDNRLifetime		{ return T_AdvDNRLifetime; }
+AdvDNRAddr		{ return T_AdvDNRAddr; }
+AdvDNRSvcAlpn		{ return T_AdvDNRSvcAlpn; }
+AdvDNRSvcPort		{ return T_AdvDNRSvcPort; }
+AdvDNRSvcDohpath	{ return T_AdvDNRSvcDohpath; }
+FlushDNR		{ return T_FlushDNR; }
 
 MinDelayBetweenRAs      { return T_MinDelayBetweenRAs; }
 
@@ -171,6 +180,12 @@ high		{ yylval.snum = 1; return SIGNEDNUMBER; }
 
 {string}	{
 			static char string[256];
+
+			if (yyleng >= (int)sizeof(string)) {
+				flog(LOG_ERR, "string constant exceeds %zu bytes at line %d",
+					sizeof(string) - 1, num_lines);
+				return T_BAD_TOKEN;
+			}
 
 			strncpy(string, yytext, sizeof(string));
 			string[sizeof(string)-1] = '\0';

--- a/send.c
+++ b/send.c
@@ -27,7 +27,10 @@ static void decrement_lifetime(const time_t secs, uint32_t *lifetime);
 static void update_iface_times(struct Interface *iface);
 
 // Option helpers
+static size_t serialize_domain_name(struct safe_buffer *sb, char const *name);
 static size_t serialize_domain_names(struct safe_buffer *safe_buffer, struct AdvDNSSL const *dnssl);
+static size_t alpn_wire_len(char const *alpn);
+static void alpn_wire_append(struct safe_buffer *sb, char const *alpn);
 static int get_prefix_lifetimes(struct AdvPrefix const *prefix, unsigned int *valid_lft, unsigned int *preferred_lft);
 static void limit_prefix_lifetimes(struct AdvPrefix *prefix);
 
@@ -53,6 +56,8 @@ static struct safe_buffer_list *add_ra_options_rdnss(struct safe_buffer_list *sb
 						     struct AdvRDNSS const *rdnss, int cease_adv, struct in6_addr const *dest);
 static struct safe_buffer_list *add_ra_options_dnssl(struct safe_buffer_list *sbl, struct Interface const *iface,
 						     struct AdvDNSSL const *dnssl, int cease_adv, struct in6_addr const *dest);
+static struct safe_buffer_list *add_ra_options_dnr(struct safe_buffer_list *sbl, struct Interface const *iface,
+						   struct AdvDNR const *dnr, int cease_adv, struct in6_addr const *dest);
 
 // Scheduling of options per RFC7772
 static int schedule_helper(struct in6_addr const *dest, struct Interface const *iface, int option_lifetime);
@@ -60,6 +65,7 @@ static int schedule_option_prefix(struct in6_addr const *dest, struct Interface 
 static int schedule_option_route(struct in6_addr const *dest, struct Interface const *iface, struct AdvRoute const *route);
 static int schedule_option_rdnss(struct in6_addr const *dest, struct Interface const *iface, struct AdvRDNSS const *rdnss);
 static int schedule_option_dnssl(struct in6_addr const *dest, struct Interface const *iface, struct AdvDNSSL const *dnssl);
+static int schedule_option_dnr(struct in6_addr const *dest, struct Interface const *iface, struct AdvDNR const *dnr);
 static int schedule_option_mtu(struct in6_addr const *dest, struct Interface const *iface);
 static int schedule_option_sllao(struct in6_addr const *dest, struct Interface const *iface);
 static int schedule_option_mipv6_rtr_adv_interval(struct in6_addr const *dest, struct Interface const *iface);
@@ -528,39 +534,96 @@ static struct safe_buffer_list *add_ra_options_prefix(struct safe_buffer_list *s
  *   MUST be padded with zeros.
  */
 /* clang-format on */
+static size_t serialize_domain_name(struct safe_buffer *sb, char const *name)
+{
+	size_t len = 0;
+	size_t initial_used = sb->used;
+	char const *label = name;
+
+	while (label[0] != '\0') {
+		size_t raw_len;
+
+		if (strchr(label, '.') == NULL)
+			raw_len = strlen(label);
+		else
+			raw_len = (size_t)(strchr(label, '.') - label);
+
+		// RFC 1035 §3.1: labels must be 63 octets or less
+		if (raw_len > 63) {
+			flog(LOG_ERR, "DNS label exceeds 63 octets (RFC 1035 §3.1): %.*s", (int)raw_len, label);
+			sb->used = initial_used;
+			return 0;
+		}
+
+		unsigned char label_len = (unsigned char)raw_len;
+
+		// +8 is for null & padding, only allocate once.
+		safe_buffer_resize(sb, sb->used + sizeof(label_len) + label_len + 8);
+		len += safe_buffer_append(sb, &label_len, sizeof(label_len));
+		len += safe_buffer_append(sb, label, label_len);
+
+		label += label_len;
+
+		if (label[0] == '.') {
+			label++;
+		}
+
+		if (label[0] == '\0') {
+			char zero = 0;
+			len += safe_buffer_append(sb, &zero, sizeof(zero));
+		}
+	}
+	return len;
+}
+
 static size_t serialize_domain_names(struct safe_buffer *safe_buffer, struct AdvDNSSL const *dnssl)
 {
 	size_t len = 0;
 
 	for (int i = 0; i < dnssl->AdvDNSSLNumber; i++) {
-		char *label = dnssl->AdvDNSSLSuffixes[i];
-
-		while (label[0] != '\0') {
-			unsigned char label_len;
-
-			if (strchr(label, '.') == NULL)
-				label_len = (unsigned char)strlen(label);
-			else
-				label_len = (unsigned char)(strchr(label, '.') - label);
-
-			// +8 is for null & padding, only allocate once.
-			safe_buffer_resize(safe_buffer, safe_buffer->used + sizeof(label_len) + label_len + 8);
-			len += safe_buffer_append(safe_buffer, &label_len, sizeof(label_len));
-			len += safe_buffer_append(safe_buffer, label, label_len);
-
-			label += label_len;
-
-			if (label[0] == '.') {
-				label++;
-			}
-
-			if (label[0] == '\0') {
-				char zero = 0;
-				len += safe_buffer_append(safe_buffer, &zero, sizeof(zero));
-			}
-		}
+		len += serialize_domain_name(safe_buffer, dnssl->AdvDNSSLSuffixes[i]);
 	}
 	return len;
+}
+
+static size_t alpn_wire_len(char const *alpn)
+{
+	size_t total = 0;
+	char const *p = alpn;
+
+	while (*p) {
+		char const *comma = strchr(p, ',');
+		size_t tok = comma ? comma - p : strlen(p);
+		if (tok > 255) {
+			flog(LOG_ERR, "ALPN protocol identifier exceeds 255 bytes");
+			return 0;
+		}
+		total += 1 + tok;
+		p += tok;
+		if (*p == ',')
+			p++;
+	}
+	return total;
+}
+
+static void alpn_wire_append(struct safe_buffer *sb, char const *alpn)
+{
+	char const *p = alpn;
+
+	while (*p) {
+		char const *comma = strchr(p, ',');
+		size_t tok = comma ? comma - p : strlen(p);
+		if (tok > 255) {
+			flog(LOG_ERR, "ALPN protocol identifier exceeds 255 bytes");
+			return;
+		}
+		uint8_t len8 = (uint8_t)tok;
+		safe_buffer_append(sb, &len8, 1);
+		safe_buffer_append(sb, p, tok);
+		p += tok;
+		if (*p == ',')
+			p++;
+	}
 }
 
 static struct safe_buffer_list *add_ra_options_route(struct safe_buffer_list *sbl, struct Interface const *iface,
@@ -705,6 +768,145 @@ static struct safe_buffer_list *add_ra_options_dnssl(struct safe_buffer_list *sb
 		dnssl = dnssl->next;
 	}
 	safe_buffer_free(serialized_domains);
+	return sbl;
+}
+
+static struct safe_buffer_list *add_ra_options_dnr(struct safe_buffer_list *sbl, struct Interface const *iface,
+						   struct AdvDNR const *dnr, int cease_adv, struct in6_addr const *dest)
+{
+	struct safe_buffer *serialized_adn = new_safe_buffer();
+
+	while (dnr) {
+		if (!cease_adv && !schedule_option_dnr(dest, iface, dnr)) {
+			dnr = dnr->next;
+			continue;
+		}
+
+		if (!dnr->AdvDNRADN) {
+			flog(LOG_ERR, "DNR entry has NULL ADN; skipping");
+			dnr = dnr->next;
+			continue;
+		}
+		serialized_adn->used = 0;
+		size_t const adn_wire_bytes = serialize_domain_name(serialized_adn, dnr->AdvDNRADN);
+		if (adn_wire_bytes == 0) {
+			flog(LOG_ERR, "DNR ADN serialization failed for '%s'; skipping", dnr->AdvDNRADN);
+			dnr = dnr->next;
+			continue;
+		}
+		// RFC 1035 §3.1: total encoded name must be <= 255 bytes
+		if (adn_wire_bytes > 255) {
+			flog(LOG_ERR, "DNR ADN '%s' encodes to %zu bytes, exceeding RFC 1035 limit of 255; skipping",
+			     dnr->AdvDNRADN, adn_wire_bytes);
+			dnr = dnr->next;
+			continue;
+		}
+
+		// Computed once and reused below for both the size accounting and the
+		// SvcParamValue itself, so a rejected (oversized) item can't cause the two to disagree.
+		size_t const alpn_bytes = dnr->AdvDNRSvcAlpn ? alpn_wire_len(dnr->AdvDNRSvcAlpn) : 0;
+		int const include_alpn = dnr->AdvDNRSvcAlpn && alpn_bytes > 0;
+
+		size_t svcparams_bytes = 0;
+		if (include_alpn)
+			svcparams_bytes += 4 + alpn_bytes;
+		if (dnr->AdvDNRSvcPort)
+			svcparams_bytes += 4 + 2;
+		if (dnr->AdvDNRSvcDohpath)
+			svcparams_bytes += 4 + strlen(dnr->AdvDNRSvcDohpath);
+
+		int const adn_only = (dnr->AdvDNRNumber == 0);
+
+		if (!adn_only && !include_alpn)
+			flog(LOG_WARNING,
+			     "DNR option for '%s' has no ALPN SvcParam; "
+			     "RFC 9463 §6.1 recommends including 'alpn'",
+			     dnr->AdvDNRADN);
+		size_t bytes = sizeof(struct nd_opt_dnr_info_local) + sizeof(uint16_t) + adn_wire_bytes;
+		if (!adn_only)
+			bytes += sizeof(uint16_t)
+				 + (size_t)dnr->AdvDNRNumber * sizeof(struct in6_addr)
+				 + sizeof(uint16_t) + svcparams_bytes;
+
+		// RFC 9463 §6.1, RFC 4861 §4.6: pad to multiple of 8 octets
+		size_t const nd_opt_dnri_len = (bytes + 7) / 8;
+		size_t const bytes_with_padding = nd_opt_dnri_len * 8;
+
+		if (nd_opt_dnri_len > 255) {
+			flog(LOG_ERR,
+			     "Skipping option: DNR too long (%zu) for RA, must be <= %d bytes including header and padding",
+			     bytes_with_padding, 255 * 8);
+			dnr = dnr->next;
+			continue;
+		}
+
+		struct nd_opt_dnr_info_local dnrinfo;
+		memset(&dnrinfo, 0, sizeof(dnrinfo));
+		dnrinfo.nd_opt_dnri_type = ND_OPT_DNR_INFORMATION;
+		dnrinfo.nd_opt_dnri_len = (uint8_t)nd_opt_dnri_len;
+		dnrinfo.nd_opt_dnri_priority = htons(dnr->AdvDNRPriority);
+
+		if (cease_adv && dnr->FlushDNRFlag) {
+			dnrinfo.nd_opt_dnri_lifetime = 0;
+		} else {
+			dnrinfo.nd_opt_dnri_lifetime = htonl(dnr->AdvDNRLifetime);
+		}
+
+		sbl = safe_buffer_list_append(sbl);
+		safe_buffer_resize(sbl->sb, sbl->sb->used + bytes_with_padding);
+
+		safe_buffer_append(sbl->sb, &dnrinfo, sizeof(dnrinfo));
+
+		uint16_t const adn_len_net = htons((uint16_t)adn_wire_bytes);
+		safe_buffer_append(sbl->sb, &adn_len_net, sizeof(uint16_t));
+		safe_buffer_append(sbl->sb, serialized_adn->buffer, adn_wire_bytes);
+
+		if (!adn_only) {
+			uint16_t const addr_len_net = htons((uint16_t)(dnr->AdvDNRNumber * sizeof(struct in6_addr)));
+			safe_buffer_append(sbl->sb, &addr_len_net, sizeof(uint16_t));
+			for (int i = 0; i < dnr->AdvDNRNumber; i++) {
+				safe_buffer_append(sbl->sb, &dnr->AdvDNRAddrs[i], sizeof(struct in6_addr));
+			}
+
+			uint16_t const svcparams_len_net = htons((uint16_t)svcparams_bytes);
+			safe_buffer_append(sbl->sb, &svcparams_len_net, sizeof(uint16_t));
+
+			// RFC 9460 §7.1
+			if (include_alpn) {
+				uint16_t const key = htons(DNR_SVCPARAM_KEY_ALPN);
+				uint16_t const vlen = htons((uint16_t)alpn_bytes);
+				safe_buffer_append(sbl->sb, &key, sizeof(uint16_t));
+				safe_buffer_append(sbl->sb, &vlen, sizeof(uint16_t));
+				alpn_wire_append(sbl->sb, dnr->AdvDNRSvcAlpn);
+			}
+
+			// RFC 9460 §7.2
+			if (dnr->AdvDNRSvcPort) {
+				uint16_t const key = htons(DNR_SVCPARAM_KEY_PORT);
+				uint16_t const vlen = htons(sizeof(uint16_t));
+				uint16_t const val = htons(dnr->AdvDNRSvcPort);
+				safe_buffer_append(sbl->sb, &key, sizeof(uint16_t));
+				safe_buffer_append(sbl->sb, &vlen, sizeof(uint16_t));
+				safe_buffer_append(sbl->sb, &val, sizeof(uint16_t));
+			}
+
+			// RFC 9461 §5.1
+			if (dnr->AdvDNRSvcDohpath) {
+				size_t const dlen = strlen(dnr->AdvDNRSvcDohpath);
+				uint16_t const key = htons(DNR_SVCPARAM_KEY_DOHPATH);
+				uint16_t const vlen = htons((uint16_t)dlen);
+				safe_buffer_append(sbl->sb, &key, sizeof(uint16_t));
+				safe_buffer_append(sbl->sb, &vlen, sizeof(uint16_t));
+				safe_buffer_append(sbl->sb, dnr->AdvDNRSvcDohpath, dlen);
+			}
+		}
+
+		safe_buffer_pad(sbl->sb, bytes_with_padding - bytes);
+
+		dnr = dnr->next;
+	}
+
+	safe_buffer_free(serialized_adn);
 	return sbl;
 }
 
@@ -858,6 +1060,10 @@ static struct safe_buffer_list *build_ra_options(struct Interface const *iface, 
 
 	if (iface->AdvDNSSLList) {
 		cur = add_ra_options_dnssl(cur, iface, iface->AdvDNSSLList, iface->state_info.cease_adv, dest);
+	}
+
+	if (iface->AdvDNRList) {
+		cur = add_ra_options_dnr(cur, iface, iface->AdvDNRList, iface->state_info.cease_adv, dest);
 	}
 
 	if (iface->AdvLinkMTU != 0 && schedule_option_mtu(dest, iface)) {
@@ -1070,6 +1276,11 @@ static int schedule_option_rdnss(struct in6_addr const *dest, struct Interface c
 static int schedule_option_dnssl(struct in6_addr const *dest, struct Interface const *iface, struct AdvDNSSL const *dnssl)
 {
 	return schedule_helper(dest, iface, dnssl->AdvDNSSLLifetime);
+}
+
+static int schedule_option_dnr(struct in6_addr const *dest, struct Interface const *iface, struct AdvDNR const *dnr)
+{
+	return schedule_helper(dest, iface, dnr->AdvDNRLifetime);
 }
 
 static int schedule_option_mtu(struct in6_addr const *dest, struct Interface const *iface)

--- a/test/send.c
+++ b/test/send.c
@@ -813,6 +813,161 @@ START_TEST(test_add_ra_option_abro)
 }
 END_TEST
 
+START_TEST(test_add_ra_options_dnr_adn_only)
+{
+	struct Interface *iface = readin_config("test/test_dnr_adn_only.conf");
+	ck_assert_ptr_ne(0, iface);
+
+	struct safe_buffer_list *sbl = new_safe_buffer_list();
+	struct safe_buffer sb = SAFE_BUFFER_INIT;
+
+	add_ra_options_dnr(sbl, iface, iface->AdvDNRList, iface->state_info.cease_adv, NULL);
+	safe_buffer_list_to_safe_buffer(sbl, &sb);
+	safe_buffer_list_free(sbl);
+	free_ifaces(iface);
+
+#ifdef PRINT_SAFE_BUFFER
+	char buf[4096];
+	snprint_safe_buffer(buf, 4096, &sb);
+	ck_assert_msg(0, "\n%s", (char *)&buf);
+#else
+	unsigned char expected[] = {
+	    // type=144, len=4
+	    0x90, 0x04,
+	    // priority=100
+	    0x00, 0x64,
+	    // lifetime=1800 (0x708)
+	    0x00, 0x00, 0x07, 0x08,
+	    // ADN Length=18 (0x12)
+	    0x00, 0x12,
+	    // doh1.example.com in DNS wire format
+	    0x04, 0x64, 0x6f, 0x68, 0x31, // \x04 d o h 1
+	    0x07, 0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65, // \x07 e x a m p l e
+	    0x03, 0x63, 0x6f, 0x6d, // \x03 c o m
+	    0x00, // root label
+	    // padding: 4 bytes
+	    0x00, 0x00, 0x00, 0x00,
+	};
+
+	ck_assert_int_eq(sizeof(expected), sb.used);
+	ck_assert_int_eq(0, memcmp(expected, sb.buffer, sb.used));
+#endif
+	safe_buffer_free(&sb);
+}
+END_TEST
+
+START_TEST(test_add_ra_options_dnr_addrs)
+{
+	struct Interface *iface = readin_config("test/test_dnr_addrs.conf");
+	ck_assert_ptr_ne(0, iface);
+
+	struct safe_buffer_list *sbl = new_safe_buffer_list();
+	struct safe_buffer sb = SAFE_BUFFER_INIT;
+
+	add_ra_options_dnr(sbl, iface, iface->AdvDNRList, iface->state_info.cease_adv, NULL);
+	safe_buffer_list_to_safe_buffer(sbl, &sb);
+	safe_buffer_list_free(sbl);
+	free_ifaces(iface);
+
+#ifdef PRINT_SAFE_BUFFER
+	char buf[4096];
+	snprint_safe_buffer(buf, 4096, &sb);
+	ck_assert_msg(0, "\n%s", (char *)&buf);
+#else
+	unsigned char expected[] = {
+	    // type=144, len=6
+	    0x90, 0x06,
+	    // priority=100
+	    0x00, 0x64,
+	    // lifetime=1800
+	    0x00, 0x00, 0x07, 0x08,
+	    // ADN Length=18
+	    0x00, 0x12,
+	    // doh1.example.com
+	    0x04, 0x64, 0x6f, 0x68, 0x31,
+            0x07, 0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65,
+            0x03, 0x63, 0x6f, 0x6d,
+            0x00,
+	    // Addr Length=16
+	    0x00, 0x10,
+	    // 2001:db8::1
+	    0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
+	    // SvcParams Length=0
+	    0x00, 0x00,
+	};
+
+	ck_assert_int_eq(sizeof(expected), sb.used);
+	ck_assert_int_eq(0, memcmp(expected, sb.buffer, sb.used));
+#endif
+	safe_buffer_free(&sb);
+}
+END_TEST
+
+START_TEST(test_add_ra_options_dnr_svcparams)
+{
+	struct Interface *iface = readin_config("test/test_dnr_svcparams.conf");
+	ck_assert_ptr_ne(0, iface);
+
+	struct safe_buffer_list *sbl = new_safe_buffer_list();
+	struct safe_buffer sb = SAFE_BUFFER_INIT;
+
+	add_ra_options_dnr(sbl, iface, iface->AdvDNRList, iface->state_info.cease_adv, NULL);
+	safe_buffer_list_to_safe_buffer(sbl, &sb);
+	safe_buffer_list_free(sbl);
+	free_ifaces(iface);
+
+#ifdef PRINT_SAFE_BUFFER
+	char buf[4096];
+	snprint_safe_buffer(buf, 4096, &sb);
+	ck_assert_msg(0, "\n%s", (char *)&buf);
+#else
+	unsigned char expected[] = {
+	    // type=144, len=11
+	    0x90, 0x0b,
+	    // priority=100
+	    0x00, 0x64,
+	    // lifetime=1800
+	    0x00, 0x00, 0x07, 0x08,
+	    // ADN Length=18
+	    0x00, 0x12,
+	    // doh1.example.com
+	    0x04, 0x64, 0x6f, 0x68, 0x31,
+	    0x07, 0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65,
+	    0x03, 0x63, 0x6f, 0x6d,
+	    0x00,
+	    // Addr Length=16
+	    0x00, 0x10,
+	    // 2001:db8::1
+	    0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00,
+	    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
+	    // SvcParams Length=36 (0x24)
+	    0x00, 0x24,
+	    // ALPN: key=1, vlen=6, \x02h2\x02h3
+	    0x00, 0x01,
+	    0x00, 0x06,
+	    0x02, 0x68, 0x32, // \x02 h 2
+	    0x02, 0x68, 0x33, // \x02 h 3
+	    // Port: key=3, vlen=2, 443=0x01bb
+	    0x00, 0x03,
+	    0x00, 0x02,
+	    0x01, 0xbb,
+	    // Dohpath: key=7, vlen=16, "/dns-query{?dns}"
+	    0x00, 0x07,
+	    0x00, 0x10,
+	    0x2f, 0x64, 0x6e, 0x73, 0x2d, 0x71, 0x75, 0x65, // /dns-que
+	    0x72, 0x79, 0x7b, 0x3f, 0x64, 0x6e, 0x73, 0x7d, // ry{?dns}
+	    // padding: 4 bytes
+	    0x00, 0x00, 0x00, 0x00,
+	};
+
+	ck_assert_int_eq(sizeof(expected), sb.used);
+	ck_assert_int_eq(0, memcmp(expected, sb.buffer, sb.used));
+#endif
+	safe_buffer_free(&sb);
+}
+END_TEST
+
 Suite *send_suite(void)
 {
 	TCase *tc_update = tcase_create("update");
@@ -834,6 +989,9 @@ Suite *send_suite(void)
 	tcase_add_test(tc_build, test_add_ra_options_dnssl4);
 	tcase_add_test(tc_build, test_add_ra_options_dnssl5);
 	tcase_add_test(tc_build, test_add_ra_options_dnssl6);
+	tcase_add_test(tc_build, test_add_ra_options_dnr_adn_only);
+	tcase_add_test(tc_build, test_add_ra_options_dnr_addrs);
+	tcase_add_test(tc_build, test_add_ra_options_dnr_svcparams);
 	tcase_add_test(tc_build, test_add_ra_option_mtu);
 	tcase_add_test(tc_build, test_add_ra_option_sllao48);
 	tcase_add_test(tc_build, test_add_ra_option_sllao64);

--- a/test/test_dnr_addrs.conf
+++ b/test/test_dnr_addrs.conf
@@ -1,0 +1,8 @@
+interface eth0 {
+	MaxRtrAdvInterval 600;
+	DNR doh1.example.com {
+		AdvDNRPriority 100;
+		AdvDNRLifetime 1800;
+		AdvDNRAddr 2001:db8::1;
+	};
+};

--- a/test/test_dnr_adn_only.conf
+++ b/test/test_dnr_adn_only.conf
@@ -1,0 +1,7 @@
+interface eth0 {
+	MaxRtrAdvInterval 600;
+	DNR doh1.example.com {
+		AdvDNRPriority 100;
+		AdvDNRLifetime 1800;
+	};
+};

--- a/test/test_dnr_svcparams.conf
+++ b/test/test_dnr_svcparams.conf
@@ -1,0 +1,11 @@
+interface eth0 {
+	MaxRtrAdvInterval 600;
+	DNR doh1.example.com {
+		AdvDNRPriority 100;
+		AdvDNRLifetime 1800;
+		AdvDNRAddr 2001:db8::1;
+		AdvDNRSvcAlpn "h2,h3";
+		AdvDNRSvcPort 443;
+		AdvDNRSvcDohpath "/dns-query{?dns}";
+	};
+};


### PR DESCRIPTION
This PR adds the DNR configuration block, which enables radvd to advertise Encrypted DNS on the network.
It also implements a parser in `radvdump`.

Example config that tells network clients to use Cloudflare encrypted DNS, with the preferred protocol being DNS-over-QUIC, then DNS-over-TLS, and finally DNS-over-HTTPS (HTTP/2 or HTTP/3, not HTTP/1.1):

```
interface eth0 {
    MaxRtrAdvInterval 600;
    # Order of preference: doq > dot > doh
    DNR cloudflare-dns.com {
        AdvDNRPriority 1;
        AdvDNRAddr 2606:4700:4700::1111;
        AdvDNRAddr 2606:4700:4700::1001;
        AdvDNRSvcAlpn "doq";
        AdvDNRSvcPort 853;
    };
    DNR cloudflare-dns.com {
        AdvDNRPriority 2;
        AdvDNRAddr 2606:4700:4700::1111;
        AdvDNRAddr 2606:4700:4700::1001;
        AdvDNRSvcAlpn "dot";
        AdvDNRSvcPort 853;
    };
    DNR cloudflare-dns.com {
        AdvDNRPriority 3;
        AdvDNRAddr 2606:4700:4700::1111;
        AdvDNRAddr 2606:4700:4700::1001;
        AdvDNRSvcAlpn "h2,h3";
        AdvDNRSvcPort 443;
        AdvDNRSvcDohpath "/dns-query{?dns}";
    };
};
```

Some of the requirements from the RFC are simply warnings here, as it would otherwise be difficult to check (ex. Doh query string validity) and some requirements are warnings (ex. using a link-local address for DNR). It doesn't matter for radvd, since a trusted administrator is writing the config and hopefully knows what they are doing.
 
See the RFC for more details: https://datatracker.ietf.org/doc/rfc9463/

I used Claude Opus 4.8 to find and fix bugs in my implementation, and for developing the tests.

Closes: #243