### PR TITLE
Add new router advertisement RFCs to README table

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ Implementation Legend:
 | RFC8910 | PARTIAL | Captive-Portal Identification in DHCP and Router Advertisements | |
 | RFC8981 | | Privacy Extensions for Stateless Address Autoconfiguration in IPv6 | |
 | RFC9099 | | Operational Security Considerations for IPv6 Networks | |
+| RFC9463 | NONE | DHCP and Router Advertisement Options for the Discovery of Network-designated Resolvers (DNR) | |
+| RFC9762 | COMPLETE | Using Router Advertisements to Signal the Availability of DHCPv6 Prefix Delegation to Clients | |
 
 ## Other RFCs
 ^ RFC ^ Status ^ Title ^ Note Summary ^


### PR DESCRIPTION
Adds RFC 9463 and RFC 9762 to the README table. 

[RFC 9463](https://datatracker.ietf.org/doc/rfc9463/) is open in #282

[RFC 9762](https://datatracker.ietf.org/doc/rfc9762/) was implemented in 760c15f8